### PR TITLE
Adds polygonal tundra subsidence and micro topographic parameter calculations

### DIFF
--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -188,18 +188,21 @@ contains
          ! subsidence is integral of melt profile:
          subsidence(c) = subsidence(c) + sum(melt_profile)
 
+         ! limit subsidence to 0.4 m
+         subsidence(c) = min(0.4_r8, subsidence(c))
+
          ! update ice wedge polygon microtopographic parameters if in polygonal ground
-         ! TODO: need to retrieve landunit this column is on.
-         if (lun_pp%ispolygon(c)) then
-            if (lun_pp%polygontype(c) .eq. ilowcenpoly) then
+         !rf - min/max logic may be redunant w/ subsidence limiter above
+         if (lun_pp%ispolygon(col_pp%landunit(c))) then
+            if (lun_pp%polygontype(col_pp%landunit(c)) .eq. ilowcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
-               ddep(c) = 0.15_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. iflatcenpoly) then
-               rmax(c) = 0.1_r8  ! TODO - update based on subsidence calcs.
-               vexc(c) = 0.05_r8 ! TODO - update based on subsidence calcs.
-               ddep(c) = 0.01_r8 ! TODO - update based on subsidence calcs.
-            elseif (lun_pp%polygontype(c) .eq. ihighcenpoly) then
+               ddep(c) = min(0.05_r8, max(0.15_r8 - 0.25_r8*subsidence(c), 0.15_r8))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. iflatcenpoly) then
+               rmax(c) = min(0.1_r8, max(0.4_r8, 0.1_r8 + 0.75_r8*subsidence(c)))
+               vexc(c) = min(0.05_r8, max(0.2_r8, 0.05_r8 + 0.375_r8*subsidence(c)))
+               ddep(c) = min(0.01_r8, max(0.05_r8, 0.01_r8 + 0.1_r8*subsidence(c)))
+            elseif (lun_pp%polygontype(col_pp%landunit(c)) .eq. ihighcenpoly) then
                rmax(c) = 0.4_r8
                vexc(c) = 0.2_r8
                ddep(c) = 0.05_r8

--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -12,7 +12,9 @@ module ActiveLayerMod
   use CanopyStateType , only : canopystate_type
   use GridcellType    , only : grc_pp
   use ColumnType      , only : col_pp
-  use ColumnDataType  , only : col_es
+  use ColumnDataType  , only : col_es, col_ws
+  use LandunitType    , only : lun_pp
+  use landunit_varcon , only : ilowcenpoly, iflatcenpoly, ihighcenpoly
   !
   implicit none
   save
@@ -47,7 +49,7 @@ contains
     use elm_varpar       , only : nlevgrnd
     use elm_time_manager , only : get_curr_date, get_step_size
     use elm_varctl       , only : iulog
-    use elm_varcon       , only : zsoi
+    use elm_varcon       , only : zsoi, dzsoi
     !
     ! !ARGUMENTS:
     integer                , intent(in)    :: num_soilc       ! number of soil columns in filter
@@ -56,16 +58,17 @@ contains
     type(canopystate_type) , intent(inout) :: canopystate_vars
     !
     ! !LOCAL VARIABLES:
-    integer  :: c, j, fc, g                     ! counters
-    integer  :: alt_ind                         ! index of base of activel layer
-    integer  :: year                            ! year (0, ...) for nstep+1
-    integer  :: mon                             ! month (1, ..., 12) for nstep+1
-    integer  :: day                             ! day of month (1, ..., 31) for nstep+1
-    integer  :: sec                             ! seconds into current date for nstep+1
-    integer  :: dtime                           ! time step length in seconds
-    integer  :: k_frz                           ! index of first nonfrozen soil layer
-    logical  :: found_thawlayer                 ! used to break loop when first unfrozen layer reached
-    real(r8) :: t1, t2, z1, z2                  ! temporary variables
+    integer  :: c, j, fc, g                       ! counters
+    integer  :: alt_ind                           ! index of base of active layer
+    integer  :: year                              ! year (0, ...) for nstep+1
+    integer  :: mon                               ! month (1, ..., 12) for nstep+1
+    integer  :: day                               ! day of month (1, ..., 31) for nstep+1
+    integer  :: sec                               ! seconds into current date for nstep+1
+    integer  :: dtime                             ! time step length in seconds
+    integer  :: k_frz                             ! index of first nonfrozen soil layer
+    logical  :: found_thawlayer                   ! used to break loop when first unfrozen layer reached
+    real(r8) :: t1, t2, z1, z2                    ! temporary variables
+    real(r8), dimension(nlevgrnd) :: melt_profile ! profile of melted excess ice
     !-----------------------------------------------------------------------
 
     associate(                                                                &
@@ -78,7 +81,12 @@ contains
          alt_indx             =>    canopystate_vars%alt_indx_col        ,      & ! Output:  [integer  (:)   ]  current depth of thaw
          altmax_indx          =>    canopystate_vars%altmax_indx_col     ,      & ! Output:  [integer  (:)   ]  maximum annual depth of thaw
          altmax_lastyear_indx =>    canopystate_vars%altmax_lastyear_indx_col , & ! Output:  [integer  (:)   ]  prior year maximum annual depth of thaw
-         altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col       & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
+         altmax_ever_indx     =>    canopystate_vars%altmax_ever_indx_col,      & ! Output:  [integer  (:)   ]  maximum thaw depth since initialization
+         excess_ice           =>    col_ws%excess_ice                    ,      & ! Input:   [real(r8) (:,:) ]  depth variable excess ice content in soil column (-)
+         rmax                 =>    col_pp%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
+         vexc                 =>    col_pp%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
+         ddep                 =>    col_pp%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
+         subsidence           =>    col_pp%iwp_subsidence                       & ! Input/output:[real(r8) (:)   ]  ice wedge polygon subsidence (m)
          )
 
       ! on a set annual timestep, update annual maxima
@@ -153,15 +161,53 @@ contains
             altmax_indx(c) = alt_indx(c)
          endif
          if (alt(c) > altmax_ever(c)) then
-            if (spinup_state .eq. 0) then !overwrite if in spinup
+            if (spinup_state .eq. 0) then
                 altmax_ever(c) = alt(c)
                 altmax_ever_indx(c) = alt_indx(c)
-            else
+            else !overwrite if in spinup
                 altmax_ever(c) = 0._r8
                 altmax_ever_indx(c) = 0
             endif
          endif
 
+         ! update subsidence based on change in ALT
+         ! melt_profile stores the amount of excess_ice
+         ! melted in this timestep.
+         do j = nlevgrnd-1,1,-1
+            if (j < k_frz) then
+               melt_profile(j) = 0.0_r8
+            else if (j .eq. k_frz) then
+               melt_profile(j) = excess_ice(c,j) + ((z2-alt(c))/(z2-z1))*excess_ice(c,j+1) ! TODO: check indices here!!
+            else
+               melt_profile(j) = excess_ice(c,j)
+            end if
+            ! calculate subsidence at this layer:
+            melt_profile(j) = melt_profile(j) * dzsoi(j)
+         end do
+
+         ! subsidence is integral of melt profile:
+         subsidence(c) = subsidence(c) + sum(melt_profile)
+
+         ! update ice wedge polygon microtopographic parameters if in polygonal ground
+         ! TODO: need to retrieve landunit this column is on.
+         if (lun_pp%ispolygon(c)) then
+            if (lun_pp%polygontype(c) .eq. ilowcenpoly) then
+               rmax(c) = 0.4_r8
+               vexc(c) = 0.2_r8
+               ddep(c) = 0.15_r8 ! TODO - update based on subsidence calcs.
+            elseif (lun_pp%polygontype(c) .eq. iflatcenpoly) then
+               rmax(c) = 0.1_r8  ! TODO - update based on subsidence calcs.
+               vexc(c) = 0.05_r8 ! TODO - update based on subsidence calcs.
+               ddep(c) = 0.01_r8 ! TODO - update based on subsidence calcs.
+            elseif (lun_pp%polygontype(c) .eq. ihighcenpoly) then
+               rmax(c) = 0.4_r8
+               vexc(c) = 0.2_r8
+               ddep(c) = 0.05_r8
+            else
+               !call endrun !<- TODO: needed? Potential way to prevent unintended updating of microtopography
+               ! if polygonal ground is misspecified on surface file.
+            endif
+         endif
       end do
 
     end associate

--- a/components/elm/src/data_types/ColumnType.F90
+++ b/components/elm/src/data_types/ColumnType.F90
@@ -49,18 +49,19 @@ module ColumnType
      logical , pointer :: active       (:) => null() ! true=>do computations on this column
 
      ! topography
-     real(r8), pointer :: glc_topo     (:) => null() ! surface elevation (m)
-     real(r8), pointer :: micro_sigma  (:) => null() ! microtopography pdf sigma (m)
-     real(r8), pointer :: n_melt       (:) => null() ! SCA shape parameter
-     real(r8), pointer :: topo_slope   (:) => null() ! gridcell topographic slope
-     real(r8), pointer :: topo_std     (:) => null() ! gridcell elevation standard deviation
-     real(r8), pointer :: hslp_p10     (:,:) => null() ! hillslope slope percentiles (unitless)
-     integer, pointer  :: nlevbed      (:) => null() ! number of layers to bedrock
-     real(r8), pointer :: zibed        (:) => null() ! bedrock depth in model (interface level at nlevbed)
-     real(r8), pointer :: iwp_microrel (:) => null() ! ice wedge polygon microtopographic relief (m)
-     real(r8), pointer :: iwp_exclvol  (:) => null() ! ice wedge polygon excluded volume (m)
-     real(r8), pointer :: iwp_ddep     (:) => null() ! ice wedge polygon depression depth (m)
-     real(r8), pointer :: meangradz    (:) => null() ! mean topographic gradient at the column level
+     real(r8), pointer :: glc_topo      (:) => null() ! surface elevation (m)
+     real(r8), pointer :: micro_sigma   (:) => null() ! microtopography pdf sigma (m)
+     real(r8), pointer :: n_melt        (:) => null() ! SCA shape parameter
+     real(r8), pointer :: topo_slope    (:) => null() ! gridcell topographic slope
+     real(r8), pointer :: topo_std      (:) => null() ! gridcell elevation standard deviation
+     real(r8), pointer :: hslp_p10      (:,:) => null() ! hillslope slope percentiles (unitless)
+     integer, pointer  :: nlevbed       (:) => null() ! number of layers to bedrock
+     real(r8), pointer :: zibed         (:) => null() ! bedrock depth in model (interface level at nlevbed)
+     real(r8), pointer :: iwp_microrel  (:) => null() ! ice wedge polygon microtopographic relief (m)
+     real(r8), pointer :: iwp_exclvol   (:) => null() ! ice wedge polygon excluded volume (m)
+     real(r8), pointer :: iwp_ddep      (:) => null() ! ice wedge polygon depression depth (m)
+     real(r8), pointer :: iwp_subsidence(:) => null() ! ice wedge polygon ground subsidence (m)
+     real(r8), pointer :: meangradz     (:) => null() ! mean topographic gradient at the column level
 
      ! vertical levels
      integer , pointer :: snl          (:)   => null() ! number of snow layers
@@ -135,12 +136,18 @@ contains
     allocate(this%hslp_p10    (begc:endc,nlevslp))             ; this%hslp_p10    (:,:) = spval
     allocate(this%nlevbed     (begc:endc))                     ; this%nlevbed     (:)   = ispval
     allocate(this%zibed       (begc:endc))                     ; this%zibed       (:)   = spval
+    ! polygonal tundra/ice wedge polygons:
+    allocate(this%iwp_microrel  (begc:endc))                   ; this%iwp_microrel  (:) = spval
+    allocate(this%iwp_exclvol   (begc:endc))                   ; this%iwp_exclvol   (:) = spval
+    allocate(this%iwp_ddep      (begc:endc))                   ; this%iwp_ddep      (:) = spval
+    allocate(this%iwp_subsidence(begc:endc))                   ; this%iwp_subsidence(:) = spval
+    allocate(this%meangradz     (begc:endc))                   ; this%meangradz     (:) = spval
 
     allocate(this%hydrologically_active(begc:endc))            ; this%hydrologically_active(:) = .false.
 
     ! Assume that columns are not fates columns until fates initialization begins
     allocate(this%is_fates(begc:endc)); this%is_fates(:) = .false.
-    
+
   end subroutine col_pp_init
 
   !------------------------------------------------------------------------
@@ -177,9 +184,14 @@ contains
     deallocate(this%hslp_p10   )
     deallocate(this%nlevbed    )
     deallocate(this%zibed      )
+    deallocate(this%iwp_microrel)
+    deallocate(this%iwp_exclvol )
+    deallocate(this%iwp_ddep    )
+    deallocate(this%iwp_subsidence)
+    deallocate(this%meangradz     )
     deallocate(this%hydrologically_active)
     deallocate(this%is_fates)
-    
+
   end subroutine col_pp_clean
 
 end module ColumnType


### PR DESCRIPTION
Completes build out of infrastructure needed for polygonal tundra subsidence and update of microtopographic parameters, including allocating variables in column physical properties data structure.

Subsidence calculated as integral of melted depth of excess ice, capped at 0.4m
Microtopographic relief calculated as either constant or linear ramps based on subsidence depth, depending on polygon "trajectory" (e.g., low -> high, flat -> high, high -> high).