### PR TITLE
Merge vegetation updates for IM3

### DIFF
--- a/.github/workflows/ci-compile-test.yml
+++ b/.github/workflows/ci-compile-test.yml
@@ -1,0 +1,56 @@
+name: CI
+on:
+  push:
+    branches:
+      - '**'
+jobs:
+  container-test-job:
+    runs-on: ubuntu-latest
+    container:
+      image: rfiorella/e3sm-dev:latest
+    steps:
+    - name: Check out the NGEE-Arctic-E3SM repo
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+        submodules: true
+    - name: Setup cime and input datafiles
+      run: |
+        mkdir ~/.cime 
+        cp /home/e3smuser/.cime/* /github/home/.cime/
+        git clone https://github.com/rfiorella/pt-e3sm-inputdata /home/e3smuser/inputdata
+        cd /home/e3smuser/inputdata/lnd/clm2/firedata
+        tar -zxvf clmforc.Li_2012_hdm_0.5x0.5_AVHRR_simyr1850-2010_c130401.nc.tar.gz
+        cd /home/e3smuser/inputdata/atm/datm7/NASA_LIS/
+        tar -zxvf clmforc.Li_2012_climo1995-2011.T62.lnfm_c130327.nc.tar.gz
+        tar -zxvf clmforc.Li_2012_climo1995-2011.T62.lnfm_Total_c140423.nc.tar.gz
+        ls -v /home/e3smuser/inputdata/atm/datm7/NASA_LIS/
+    - name: create new case and setup
+      run: |
+        cd cime/scripts && ./create_newcase --mach docker --res ELM_USRDAT --compset ICB1850CNPRDCTCBC --case ~/output/ci_test \
+        && cd ~/output/ci_test
+        ./xmlchange MOSART_MODE=NULL,DOUT_S=FALSE,DIN_LOC_ROOT=/home/e3smuser/inputdata
+        ./xmlchange DIN_LOC_ROOT_CLMFORC=/home/e3smuser/inputdata/atm/datm7
+        ./xmlchange ELM_USRDAT_NAME=1x1pt_AK-TLG
+        ./xmlchange ATM_DOMAIN_PATH=/home/e3smuser/inputdata/share/domains/domain.clm
+        ./xmlchange LND_DOMAIN_PATH=/home/e3smuser/inputdata/share/domains/domain.clm
+        ./xmlchange ATM_DOMAIN_FILE=domain.lnd.1x1pt_teller-GRID_navy.nc
+        ./xmlchange LND_DOMAIN_FILE=domain.lnd.1x1pt_teller-GRID_navy.nc
+        ./xmlchange PIO_TYPENAME=netcdf,NTASKS=1,NTHRDS=1
+        ./xmlchange STOP_OPTION=nyears,STOP_N=5
+        ./xmlchange BATCH_SYSTEM=none
+        echo "&clm_inparm" >> user_nl_elm
+        echo " do_budgets = .false." >> user_nl_elm
+        echo " use_nofire = .true." >> user_nl_elm
+        echo " metdata_type = 'gswp3'" >> user_nl_elm
+        echo " metdata_bypass = '/home/e3smuser/inputdata/atm/datm7/atm_forcing.datm7.GSWP3.0.5d.v2.c180716_NGEE-Grid/cpl_bypass_teller-Grid'" >> user_nl_elm
+        echo " fsurdat = '/home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_teller-GRID_simyr1850_c360x720_c171002.nc'" >> user_nl_elm
+        echo " stream_fldfilename_popdens = '/home/e3smuser/inputdata/lnd/clm2/firedata/clmforc.Li_2012_hdm_0.5x0.5_AVHRR_simyr1850-2010_c130401.nc'" >> user_nl_elm
+        ./case.setup
+        # add coupler bypass flag to cmake macros.
+        echo 'string(APPEND CPPDEFS " -DCPL_BYPASS")' >> cmake_macros/universal.cmake
+        ./case.build || cat /home/e3smuser/output/ci_test/bld/e3sm.bldlog.*
+        ./case.submit --no-batch
+        cat /home/e3smuser/output/ci_test/run/e3sm.log.*
+        cat /home/e3smuser/output/ci_test/run/lnd.log.*
+      

--- a/components/elm/src/biogeochem/VegStructUpdateMod.F90
+++ b/components/elm/src/biogeochem/VegStructUpdateMod.F90
@@ -40,6 +40,7 @@ contains
     use pftvarcon        , only : noveg, nc3crop, nc3irrig, nbrdlf_evr_shrub, nbrdlf_dcd_brl_shrub
     use pftvarcon        , only : ncorn, ncornirrig, npcropmin, ztopmx, laimx
     use pftvarcon        , only : nmiscanthus, nmiscanthusirrig, nswitchgrass, nswitchgrassirrig
+    use pftvarcon        , only : bendresist, vegshape, stocking, taper
     use elm_time_manager , only : get_rad_step_size
     use elm_varctl       , only : spinup_state, spinup_mortality_factor
     !
@@ -58,8 +59,6 @@ contains
     ! !LOCAL VARIABLES:
     integer  :: p,c,g      ! indices
     integer  :: fp         ! lake filter indices
-    real(r8) :: taper      ! ratio of height:radius_breast_height (tree allometry)
-    real(r8) :: stocking   ! #stems / ha (stocking density)
     real(r8) :: ol         ! thickness of canopy layer covered by snow (m)
     real(r8) :: fb         ! fraction of canopy layer covered by snow
     real(r8) :: tlai_old   ! for use in Zeng tsai formula
@@ -82,14 +81,16 @@ contains
     !-------------------------------------------------------------------------------
 
     associate(                                                            &
-         ivt                =>  veg_pp%itype                         ,       & ! Input:  [integer  (:) ] pft vegetation type
+         ivt                =>  veg_pp%itype                  ,       & ! Input:  [integer  (:) ] pft vegetation type
          woody              =>  veg_vp%woody                  ,       & ! Input:  [real(r8) (:) ] binary flag for woody lifeform (1=woody, 0=not woody)
          slatop             =>  veg_vp%slatop                 ,       & ! Input:  [real(r8) (:) ] specific leaf area at top of canopy, projected area basis [m^2/gC]
          dsladlai           =>  veg_vp%dsladlai               ,       & ! Input:  [real(r8) (:) ] dSLA/dLAI, projected area basis [m^2/gC]
          z0mr               =>  veg_vp%z0mr                   ,       & ! Input:  [real(r8) (:) ] ratio of momentum roughness length to canopy top height (-)
          displar            =>  veg_vp%displar                ,       & ! Input:  [real(r8) (:) ] ratio of displacement height to canopy top height (-)
          dwood              =>  veg_vp%dwood                  ,       & ! Input:  [real(r8) (:) ] density of wood (gC/m^3)
-         bend_parm          =>  veg_vp%bend_parm              ,       & ! Input:  [real(r8) (:) ] shrub bending parameter after Sturm et al. 2005 (-)
+         bendresist         =>  veg_vp%bendresist             ,       & ! Input:  [real(r8) (:) ] resistance to bending under snow loading Sturm et al. 2005 (-) [0,1]
+         vegshape           =>  veg_vp%vegshape               ,       & ! Input:  [real(r8) (:) ] vegetation shape for calculating snow buried fraction only (-) (Liston and Heimstra, 2011)
+         stocking           =>  veg_vp%stocking               ,       & ! Input:  [real(r8) (:) ] Stocking density [stems / hectare]
 
          snow_depth         =>  col_ws%snow_depth    ,       & ! Input:  [real(r8) (:) ] snow height (m)
 
@@ -114,10 +115,6 @@ contains
          )
 
       dt = real( get_rad_step_size(), r8 )
-
-      ! constant allometric parameters
-      taper = 200._r8
-      stocking = 1000._r8
 
       ! convert from stems/ha -> stems/m^2
       stocking = stocking / 10000._r8
@@ -162,24 +159,16 @@ contains
 
             if (woody(ivt(p)) == 1._r8) then
 
-               ! trees and shrubs
-
-               ! if shrubs have a squat taper
-               if (ivt(p) >= nbrdlf_evr_shrub .and. ivt(p) <= nbrdlf_dcd_brl_shrub) then
-                  taper = 10._r8
-                  ! otherwise have a tall taper
-               else
-                  taper = 200._r8
-               end if
-
-               ! trees and shrubs for now have a very simple allometry, with hard-wired
-               ! stem taper (height:radius) and hard-wired stocking density (#individuals/area)
+               ! trees and shrubs currently have a very simple allometry, based on
+               ! stem taper (height:radius) and stocking density (#individuals/area)
+               ! taper and stocking density can be set as input variables now to
+               ! change from default values set in pftvarcon.F90
                if (spinup_state >= 1) then
-                 htop(p) = ((3._r8 * deadstemc(p) * spinup_mortality_factor * taper * taper)/ &
-                      (SHR_CONST_PI * stocking * dwood(ivt(p))))**(1._r8/3._r8)
+                 htop(p) = ((3._r8 * deadstemc(p) * spinup_mortality_factor * taper(p) * taper(p))/ &
+                      (SHR_CONST_PI * stocking(p) * dwood(ivt(p))))**(1._r8/3._r8)
                else
-                 htop(p) = ((3._r8 * deadstemc(p) * taper * taper)/ &
-                      (SHR_CONST_PI * stocking * dwood(ivt(p))))**(1._r8/3._r8)
+                 htop(p) = ((3._r8 * deadstemc(p) * taper(p) * taper(p))/ &
+                      (SHR_CONST_PI * stocking(p) * dwood(ivt(p))))**(1._r8/3._r8)
                end if
 
                ! Peter Thornton, 5/3/2004
@@ -248,11 +237,10 @@ contains
 
          ! adjust lai and sai for burying by snow.
          ! snow burial fraction for short vegetation (e.g. grasses) as in
-         ! Wang and Zeng, 2007.
+         ! Liston and Hiemstra, 2011; Belke-Brea et al. 2020
          if (ivt(p) > noveg .and. ivt(p) <= nbrdlf_dcd_brl_shrub ) then
             ol = min( max(snow_depth(c)-hbot(p), 0._r8), htop(p)-hbot(p))
-         !   fb = 1._r8 - ol / max(1.e-06_r8, htop(p)-hbot(p))   ! Wang and Zeng, 2007
-            fb = 1._r8 - ol / bend_parm(p)*max(1.e-06_r8, htop(p)-hbot(p)) ! Liston and Heimstra, 2011
+            fb = 1._r8 - (ol / max(1.e-06_r8, bendresist(p) * (htop(p)-hbot(p)))) ** vegshape(p)
          else
             fb = 1._r8 - max(min(snow_depth(c),0.2_r8),0._r8)/0.2_r8   ! 0.2m is assumed
             !depth of snow required for complete burial of grasses

--- a/components/elm/src/biogeochem/VegStructUpdateMod.F90
+++ b/components/elm/src/biogeochem/VegStructUpdateMod.F90
@@ -89,6 +89,7 @@ contains
          z0mr               =>  veg_vp%z0mr                   ,       & ! Input:  [real(r8) (:) ] ratio of momentum roughness length to canopy top height (-)
          displar            =>  veg_vp%displar                ,       & ! Input:  [real(r8) (:) ] ratio of displacement height to canopy top height (-)
          dwood              =>  veg_vp%dwood                  ,       & ! Input:  [real(r8) (:) ] density of wood (gC/m^3)
+         bend_parm          =>  veg_vp%bend_parm              ,       & ! Input:  [real(r8) (:) ] shrub bending parameter after Sturm et al. 2005 (-)
 
          snow_depth         =>  col_ws%snow_depth    ,       & ! Input:  [real(r8) (:) ] snow height (m)
 
@@ -250,7 +251,8 @@ contains
          ! Wang and Zeng, 2007.
          if (ivt(p) > noveg .and. ivt(p) <= nbrdlf_dcd_brl_shrub ) then
             ol = min( max(snow_depth(c)-hbot(p), 0._r8), htop(p)-hbot(p))
-            fb = 1._r8 - ol / max(1.e-06_r8, htop(p)-hbot(p))
+         !   fb = 1._r8 - ol / max(1.e-06_r8, htop(p)-hbot(p))   ! Wang and Zeng, 2007
+            fb = 1._r8 - ol / bend_parm(p)*max(1.e-06_r8, htop(p)-hbot(p)) ! Liston and Heimstra, 2011
          else
             fb = 1._r8 - max(min(snow_depth(c),0.2_r8),0._r8)/0.2_r8   ! 0.2m is assumed
             !depth of snow required for complete burial of grasses

--- a/components/elm/src/biogeochem/VegStructUpdateMod.F90
+++ b/components/elm/src/biogeochem/VegStructUpdateMod.F90
@@ -116,9 +116,6 @@ contains
 
       dt = real( get_rad_step_size(), r8 )
 
-      ! convert from stems/ha -> stems/m^2
-      stocking = stocking / 10000._r8
-
       ! patch loop
       do fp = 1,num_soilp
          p = filter_soilp(fp)
@@ -164,11 +161,11 @@ contains
                ! taper and stocking density can be set as input variables now to
                ! change from default values set in pftvarcon.F90
                if (spinup_state >= 1) then
-                 htop(p) = ((3._r8 * deadstemc(p) * spinup_mortality_factor * taper(p) * taper(p))/ &
-                      (SHR_CONST_PI * stocking(p) * dwood(ivt(p))))**(1._r8/3._r8)
+                 htop(p) = ((3._r8 * deadstemc(p) * spinup_mortality_factor * taper(ivt(p)) * taper(ivt(p)))/ &
+                      (SHR_CONST_PI * stocking(ivt(p)) * dwood(ivt(p))))**(1._r8/3._r8)
                else
-                 htop(p) = ((3._r8 * deadstemc(p) * taper(p) * taper(p))/ &
-                      (SHR_CONST_PI * stocking(p) * dwood(ivt(p))))**(1._r8/3._r8)
+                 htop(p) = ((3._r8 * deadstemc(p) * taper(ivt(p)) * taper(ivt(p)))/ &
+                      (SHR_CONST_PI * stocking(ivt(p)) * dwood(ivt(p))))**(1._r8/3._r8)
                end if
 
                ! Peter Thornton, 5/3/2004
@@ -240,7 +237,7 @@ contains
          ! Liston and Hiemstra, 2011; Belke-Brea et al. 2020
          if (ivt(p) > noveg .and. ivt(p) <= nbrdlf_dcd_brl_shrub ) then
             ol = min( max(snow_depth(c)-hbot(p), 0._r8), htop(p)-hbot(p))
-            fb = 1._r8 - (ol / max(1.e-06_r8, bendresist(p) * (htop(p)-hbot(p)))) ** vegshape(p)
+            fb = 1._r8 - (ol / max(1.e-06_r8, bendresist(ivt(p)) * (htop(p)-hbot(p)))) ** vegshape(ivt(p))
          else
             fb = 1._r8 - max(min(snow_depth(c),0.2_r8),0._r8)/0.2_r8   ! 0.2m is assumed
             !depth of snow required for complete burial of grasses

--- a/components/elm/src/data_types/VegetationPropertiesType.F90
+++ b/components/elm/src/data_types/VegetationPropertiesType.F90
@@ -115,7 +115,7 @@ module VegetationPropertiesType
      real(r8), pointer :: lamda_ptase              => null()! critical value that incur biochemical production
      real(r8), pointer :: i_vc(:)          => null()        ! intercept of photosynthesis vcmax ~ leaf n content regression model
      real(r8), pointer :: s_vc(:)          => null()        ! slope of photosynthesis vcmax ~ leaf n content regression model
-     real(r8), pointer :: nsc_rtime(:)     => null()        ! non-structural carbon residence time 
+     real(r8), pointer :: nsc_rtime(:)     => null()        ! non-structural carbon residence time
      real(r8), pointer :: pinit_beta1(:)   => null()        ! shaping parameter for P initialization
      real(r8), pointer :: pinit_beta2(:)   => null()        ! shaping parameter for P initialization
      real(r8), pointer :: alpha_nfix(:)    => null()        ! fraction of fixed N goes directly to plant
@@ -144,8 +144,11 @@ module VegetationPropertiesType
      real(r8), pointer :: br_xr(:)         => null()   !Base rate for excess respiration
      real(r8), pointer :: tc_stress        => null()   !Critial temperature for moisture stress
 
-     !NGEE Arctic
-     real(r8), pointer :: bend_parm(:)     => null()   ! shrub bending parameter
+     ! NGEE Arctic snow-vegetation interactions
+     real(r8), pointer :: bendresist(:)       ! vegetation resistance to bending under snow loading, 0 to 1 (e.g., Liston and Hiemstra 2011)
+     real(r8), pointer :: vegshape(:)         ! shape parameter to modify shrub burial by snow (1 = parabolic, 2 = hemispheric)
+     real(r8), pointer :: stocking(:)         ! stocking density for pft (stems / hectare)
+     real(r8), pointer :: taper(:)            ! ratio of height:radius_breast_height (woody vegetation allometry)
 
    contains
    procedure, public :: Init => veg_vp_init
@@ -183,6 +186,7 @@ contains
     use pftvarcon , only : fnr, act25, kcha, koha, cpha, vcmaxha, jmaxha, tpuha
     use pftvarcon , only : lmrha, vcmaxhd, jmaxhd, tpuhd, lmrse, qe, theta_cj
     use pftvarcon , only : bbbopt, mbbopt, nstor, br_xr, tc_stress, lmrhd
+    use pftvarcon , only : bendresist, stocking, vegshape, taper ! NGEE Arctic IM3
     !
 
     class (vegetation_properties_type) :: this
@@ -307,6 +311,11 @@ contains
     allocate(this%tc_stress    )
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+    ! NGEE Arctic show-vegetation interactions
+    allocate(this%bendresist(0:numpft))                          ; this%bendresist(:)            =spval
+    allocate(this%vegshape(0:numpft))                            ; this%vegshape(:)              =spval
+    allocate(this%stocking(0:numpft))                            ; this%stocking(:)              =spval
+    allocate(this%taper(0:numpft))                               ; this%taper(:)                 =spval
 
     do m = 0,numpft
 
@@ -449,6 +458,13 @@ contains
     this%lamda_ptase   = lamda_ptase
     this%tc_stress     = tc_stress
 
+    ! NGEE Arctic - snow/vegetation interactions
+    do m = 0, numpft ! RPF - move up to earlier pft loops?
+      this%bendresist(m)  = bendresist(m)
+      this%vegshape(m)    = vegshape(m)
+      this%stocking(m)    = stocking(m)
+      this%taper(m)       = taper(m)
+    end do
   end subroutine veg_vp_init
 
 end module VegetationPropertiesType

--- a/components/elm/src/data_types/VegetationPropertiesType.F90
+++ b/components/elm/src/data_types/VegetationPropertiesType.F90
@@ -144,6 +144,8 @@ module VegetationPropertiesType
      real(r8), pointer :: br_xr(:)         => null()   !Base rate for excess respiration
      real(r8), pointer :: tc_stress        => null()   !Critial temperature for moisture stress
 
+     !NGEE Arctic
+     real(r8), pointer :: bend_parm(:)     => null()   ! shrub bending parameter
 
    contains
    procedure, public :: Init => veg_vp_init

--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -1042,7 +1042,9 @@ contains
     if (.not. readv ) then
       taper(:) = 200._r8
       do i = 0, npft - 1
-        if (woody(i) == 2) taper(i) = 10.0_r8 ! shrubs
+        ! RPF 240331 - need to revisit this section when integrating with IM4,
+        ! to make consistent with attempt to remove hard-coded pft numbers.
+        if (i >= nbrdlf_evr_shrub .and. i <= nbrdlf_dcd_brl_shrub) taper(i) = 10.0_r8 ! shrubs
       end do
     end if
 

--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -21,7 +21,7 @@ module pftvarcon
   !
   ! Vegetation type constants
   !
-  integer :: noveg                  !value for not vegetated 
+  integer :: noveg                  !value for not vegetated
   integer :: ndllf_evr_tmp_tree     !value for Needleleaf evergreen temperate tree
   integer :: ndllf_evr_brl_tree     !value for Needleleaf evergreen boreal tree
   integer :: ndllf_dcd_brl_tree     !value for Needleleaf deciduous boreal tree
@@ -68,7 +68,7 @@ module pftvarcon
   integer :: nrtubers               !value for root tubers, rain fed (rf)
   integer :: nrtubersirrig          !value for root tubers, irrigated (ir)
   integer :: nsugarcane             !value for sugarcane, rain fed (rf)
-  integer :: nsugarcaneirrig        !value for sugarcane, irrigated (ir)  
+  integer :: nsugarcaneirrig        !value for sugarcane, irrigated (ir)
   integer :: nmiscanthus            !value for miscanthus, rain fed (rf)
   integer :: nmiscanthusirrig       !value for miscanthus, irrigated (ir)
   integer :: nswitchgrass           !value for switchgrass, rain fed (rf)
@@ -76,8 +76,8 @@ module pftvarcon
   integer :: npoplar                !value for poplar, rain fed (rf)
   integer :: npoplarirrig           !value for poplar, irrigated (ir)
   integer :: nwillow                !value for willow, rain fed (rf)
-  integer :: nwillowirrig           !value for willow, irrigated (ir)  
-  
+  integer :: nwillowirrig           !value for willow, irrigated (ir)
+
   ! Number of crop functional types actually used in the model. This includes each CFT for
   ! which is_pft_known_to_model is true. Note that this includes irrigated crops even if
   ! irrigation is turned off in this run: it just excludes crop types that aren't handled
@@ -162,7 +162,7 @@ module pftvarcon
   real(r8), allocatable :: minplanttemp(:) !mininum planting temperature used in Phenology (K)
   real(r8), allocatable :: senestemp(:)    !senescence temperature for perennial crops used in Phenology (K)
   real(r8), allocatable :: min_days_senes(:)   !minimum leaf age to allow for leaf senescence
-  real(r8), allocatable :: froot_leaf(:)   !allocation parameter: new fine root C per new leaf C (gC/gC) 
+  real(r8), allocatable :: froot_leaf(:)   !allocation parameter: new fine root C per new leaf C (gC/gC)
   real(r8), allocatable :: stem_leaf(:)    !allocation parameter: new stem c per new leaf C (gC/gC)
   real(r8), allocatable :: croot_stem(:)   !allocation parameter: new coarse root C per new stem C (gC/gC)
   real(r8), allocatable :: flivewd(:)      !allocation parameter: fraction of new wood that is live (phloem and ray parenchyma) (no units)
@@ -206,7 +206,7 @@ module pftvarcon
   real(r8), allocatable :: fyield(:)       !fraction of grain that is actually harvested
   real(r8), allocatable :: root_dmx(:)     !maximum root depth
 
-  integer, parameter :: pftname_len = 40    ! max length of pftname       
+  integer, parameter :: pftname_len = 40    ! max length of pftname
   character(len=:), allocatable :: pftname(:) !PFT description
 
   real(r8), parameter :: reinickerp = 1.6_r8 !parameter in allometric equation
@@ -267,7 +267,7 @@ module pftvarcon
   real(r8), allocatable :: deadwdcp_obs_flex(:,:)     !upper and lower range of dead wood (xylem and heartwood) C:P (gC/gP)
   ! Photosynthesis parameters
   real(r8), allocatable :: fnr(:)              !fraction of nitrogen in RuBisCO
-  real(r8), allocatable :: act25(:)           
+  real(r8), allocatable :: act25(:)
   real(r8), allocatable :: kcha(:)             !Activation energy for kc
   real(r8), allocatable :: koha(:)             !Activation energy for ko
   real(r8), allocatable :: cpha(:)             !Activation energy for cp
@@ -284,7 +284,7 @@ module pftvarcon
   real(r8), allocatable :: theta_cj(:)         !
   real(r8), allocatable :: bbbopt(:)           !Ball-Berry stomatal conductance intercept
   real(r8), allocatable :: mbbopt(:)           !Ball-Berry stomatal conductance slope
-  real(r8), allocatable :: nstor(:)            !Nitrogen storage pool timescale 
+  real(r8), allocatable :: nstor(:)            !Nitrogen storage pool timescale
   real(r8), allocatable :: br_xr(:)            !Base rate for excess respiration
   real(r8)              :: tc_stress           !Critial temperature for moisture stress
   real(r8), allocatable :: vcmax_np1(:)        !vcmax~np relationship coefficient
@@ -302,8 +302,12 @@ module pftvarcon
   real(r8), allocatable :: gcbc_q(:)           !effectiveness of surface cover in reducing runoff-driven erosion
   real(r8), allocatable :: gcbr_p(:)           !effectiveness of roots in reducing rainfall-driven erosion
   real(r8), allocatable :: gcbr_q(:)           !effectiveness of roots in reducing runoff-driven erosion
-   ! NGEE Arctic shrub bending 
-  real(r8), allocatable :: bend_parm(:)        ! parameter that describes the "stiffness" of shrub branches (Sturm et al. 2005, Liston and Hiemstra 2011)
+
+  ! NGEE Arctic snow-vegetation interactions
+  real(r8), allocatable :: bendresist(:)       ! vegetation resistance to bending under snow loading, 0 to 1 (e.g., Liston and Hiemstra 2011)
+  real(r8), allocatable :: vegshape(:)         ! shape parameter to modify shrub burial by snow (1 = parabolic, 2 = hemispheric)
+  real(r8), allocatable :: stocking(:)         ! stocking density for pft (stems / hectare)
+  real(r8), allocatable :: taper(:)            ! ratio of height:radius_breast_height (woody vegetation allometry)
 
   !
   ! !PUBLIC MEMBER FUNCTIONS:
@@ -357,7 +361,7 @@ contains
     !       and finally crops, ending with soybean
     ! DO NOT CHANGE THE ORDER -- WITHOUT MODIFYING OTHER PARTS OF THE CODE WHERE THE ORDER MATTERS!
     !
-    character(len=pftname_len) :: expected_pftnames(0:mxpft) 
+    character(len=pftname_len) :: expected_pftnames(0:mxpft)
 !-----------------------------------------------------------------------
 
     expected_pftnames( 0) = 'not_vegetated                      '
@@ -412,95 +416,95 @@ contains
     expected_pftnames(49) = 'willow                             '
     expected_pftnames(50) = 'irrigated_willow                   '
 
-    allocate( dleaf         (0:mxpft) )       
-    allocate( c3psn         (0:mxpft) )       
-    allocate( xl            (0:mxpft) )          
-    allocate( rhol          (0:mxpft,numrad) ) 
-    allocate( rhos          (0:mxpft,numrad) ) 
-    allocate( taul          (0:mxpft,numrad) ) 
-    allocate( taus          (0:mxpft,numrad) ) 
-    allocate( z0mr          (0:mxpft) )        
-    allocate( displar       (0:mxpft) )     
-    allocate( roota_par     (0:mxpft) )   
-    allocate( rootb_par     (0:mxpft) )   
-    allocate( crop          (0:mxpft) )        
+    allocate( dleaf         (0:mxpft) )
+    allocate( c3psn         (0:mxpft) )
+    allocate( xl            (0:mxpft) )
+    allocate( rhol          (0:mxpft,numrad) )
+    allocate( rhos          (0:mxpft,numrad) )
+    allocate( taul          (0:mxpft,numrad) )
+    allocate( taus          (0:mxpft,numrad) )
+    allocate( z0mr          (0:mxpft) )
+    allocate( displar       (0:mxpft) )
+    allocate( roota_par     (0:mxpft) )
+    allocate( rootb_par     (0:mxpft) )
+    allocate( crop          (0:mxpft) )
     allocate( percrop       (0:mxpft) )
-    allocate( irrigated     (0:mxpft) )   
-    allocate( smpso         (0:mxpft) )       
-    allocate( smpsc         (0:mxpft) )       
-    allocate( fnitr         (0:mxpft) )       
-    allocate( slatop        (0:mxpft) )      
-    allocate( dsladlai      (0:mxpft) )    
+    allocate( irrigated     (0:mxpft) )
+    allocate( smpso         (0:mxpft) )
+    allocate( smpsc         (0:mxpft) )
+    allocate( fnitr         (0:mxpft) )
+    allocate( slatop        (0:mxpft) )
+    allocate( dsladlai      (0:mxpft) )
     allocate( leafcn        (0:mxpft) )
-    allocate( flnr          (0:mxpft) )        
-    allocate( woody         (0:mxpft) )       
-    allocate( lflitcn       (0:mxpft) )      
-    allocate( frootcn       (0:mxpft) )      
-    allocate( livewdcn      (0:mxpft) )     
-    allocate( deadwdcn      (0:mxpft) )     
+    allocate( flnr          (0:mxpft) )
+    allocate( woody         (0:mxpft) )
+    allocate( lflitcn       (0:mxpft) )
+    allocate( frootcn       (0:mxpft) )
+    allocate( livewdcn      (0:mxpft) )
+    allocate( deadwdcn      (0:mxpft) )
 
-    ! add phosphorus 
-    allocate( leafcp        (0:mxpft) )      
-    allocate( lflitcp       (0:mxpft) )      
-    allocate( frootcp       (0:mxpft) )      
-    allocate( livewdcp      (0:mxpft) )     
-    allocate( deadwdcp      (0:mxpft) )     
+    ! add phosphorus
+    allocate( leafcp        (0:mxpft) )
+    allocate( lflitcp       (0:mxpft) )
+    allocate( frootcp       (0:mxpft) )
+    allocate( livewdcp      (0:mxpft) )
+    allocate( deadwdcp      (0:mxpft) )
 
-    allocate( grperc        (0:mxpft) )       
-    allocate( grpnow        (0:mxpft) )       
+    allocate( grperc        (0:mxpft) )
+    allocate( grpnow        (0:mxpft) )
     allocate( rootprof_beta (0:mxpft) )
 
     allocate( mergetoelmpft (0:mxpft) )
     allocate( is_pft_known_to_model  (0:mxpft) )
 
-    allocate( graincn       (0:mxpft) )      
-    allocate( graincp       (0:mxpft) )      
-    allocate( mxtmp         (0:mxpft) )        
-    allocate( baset         (0:mxpft) )        
-    allocate( declfact      (0:mxpft) )     
-    allocate( bfact         (0:mxpft) )        
-    allocate( aleaff        (0:mxpft) )       
-    allocate( arootf        (0:mxpft) )       
-    allocate( astemf        (0:mxpft) )       
-    allocate( arooti        (0:mxpft) )       
-    allocate( fleafi        (0:mxpft) )       
-    allocate( allconsl      (0:mxpft) )     
-    allocate( allconss      (0:mxpft) )     
-    allocate( ztopmx        (0:mxpft) )       
-    allocate( laimx         (0:mxpft) )        
-    allocate( gddmin        (0:mxpft) )       
-    allocate( hybgdd        (0:mxpft) )       
-    allocate( lfemerg       (0:mxpft) )      
-    allocate( grnfill       (0:mxpft) )      
-    allocate( mxmat         (0:mxpft) )        
+    allocate( graincn       (0:mxpft) )
+    allocate( graincp       (0:mxpft) )
+    allocate( mxtmp         (0:mxpft) )
+    allocate( baset         (0:mxpft) )
+    allocate( declfact      (0:mxpft) )
+    allocate( bfact         (0:mxpft) )
+    allocate( aleaff        (0:mxpft) )
+    allocate( arootf        (0:mxpft) )
+    allocate( astemf        (0:mxpft) )
+    allocate( arooti        (0:mxpft) )
+    allocate( fleafi        (0:mxpft) )
+    allocate( allconsl      (0:mxpft) )
+    allocate( allconss      (0:mxpft) )
+    allocate( ztopmx        (0:mxpft) )
+    allocate( laimx         (0:mxpft) )
+    allocate( gddmin        (0:mxpft) )
+    allocate( hybgdd        (0:mxpft) )
+    allocate( lfemerg       (0:mxpft) )
+    allocate( grnfill       (0:mxpft) )
+    allocate( mxmat         (0:mxpft) )
     allocate( mnNHplantdate (0:mxpft) )
     allocate( mxNHplantdate (0:mxpft) )
     allocate( mnSHplantdate (0:mxpft) )
     allocate( mxSHplantdate (0:mxpft) )
-    allocate( planttemp     (0:mxpft) )    
-    allocate( minplanttemp  (0:mxpft) ) 
+    allocate( planttemp     (0:mxpft) )
+    allocate( minplanttemp  (0:mxpft) )
     allocate( senestemp     (0:mxpft) )
     allocate( min_days_senes (0:mxpft) )
-    allocate( froot_leaf    (0:mxpft) )   
-    allocate( stem_leaf     (0:mxpft) )    
-    allocate( croot_stem    (0:mxpft) )   
-    allocate( flivewd       (0:mxpft) )      
-    allocate( fcur          (0:mxpft) )         
-    allocate( lf_flab       (0:mxpft) )      
-    allocate( lf_fcel       (0:mxpft) )      
-    allocate( lf_flig       (0:mxpft) )      
-    allocate( fr_flab       (0:mxpft) )      
-    allocate( fr_fcel       (0:mxpft) )      
-    allocate( fr_flig       (0:mxpft) )      
-    allocate( leaf_long     (0:mxpft) )   
+    allocate( froot_leaf    (0:mxpft) )
+    allocate( stem_leaf     (0:mxpft) )
+    allocate( croot_stem    (0:mxpft) )
+    allocate( flivewd       (0:mxpft) )
+    allocate( fcur          (0:mxpft) )
+    allocate( lf_flab       (0:mxpft) )
+    allocate( lf_fcel       (0:mxpft) )
+    allocate( lf_flig       (0:mxpft) )
+    allocate( fr_flab       (0:mxpft) )
+    allocate( fr_fcel       (0:mxpft) )
+    allocate( fr_flig       (0:mxpft) )
+    allocate( leaf_long     (0:mxpft) )
     allocate( froot_long    (0:mxpft) )
-    allocate( evergreen     (0:mxpft) )    
-    allocate( stress_decid  (0:mxpft) ) 
-    allocate( season_decid  (0:mxpft) ) 
-    allocate( pconv         (0:mxpft) )        
-    allocate( pprod10       (0:mxpft) )      
-    allocate( pprod100      (0:mxpft) )     
-    allocate( pprodharv10   (0:mxpft) )  
+    allocate( evergreen     (0:mxpft) )
+    allocate( stress_decid  (0:mxpft) )
+    allocate( season_decid  (0:mxpft) )
+    allocate( pconv         (0:mxpft) )
+    allocate( pprod10       (0:mxpft) )
+    allocate( pprod100      (0:mxpft) )
+    allocate( pprodharv10   (0:mxpft) )
     allocate( cc_leaf       (0:mxpft) )
     allocate( cc_lstem      (0:mxpft) )
     allocate( cc_dstem      (0:mxpft) )
@@ -515,12 +519,12 @@ contains
     allocate( fsr_pft       (0:mxpft) )
     allocate( fd_pft        (0:mxpft) )
     allocate( manunitro     (0:mxpft) )
-    allocate( fleafcn       (0:mxpft) )  
-    allocate( ffrootcn      (0:mxpft) ) 
+    allocate( fleafcn       (0:mxpft) )
+    allocate( ffrootcn      (0:mxpft) )
     allocate( fstemcn       (0:mxpft) )
     allocate( presharv      (0:mxpft) )
     allocate( convfact      (0:mxpft) )
-    allocate( fyield        (0:mxpft) )  
+    allocate( fyield        (0:mxpft) )
     allocate( root_dmx      (0:mxpft) )
 
     if (use_crop) then
@@ -533,14 +537,14 @@ contains
     allocate( VMAX_PLANT_NO3(0:mxpft) )
     allocate( VMAX_PLANT_P(0:mxpft) )
     allocate( VMAX_MINSURF_P_vr(1:nlevdecomp_full,0:nsoilorder))
-    allocate( KM_PLANT_NH4(0:mxpft) ) 
+    allocate( KM_PLANT_NH4(0:mxpft) )
     allocate( KM_PLANT_NO3(0:mxpft) )
     allocate( KM_PLANT_P(0:mxpft) )
     allocate( KM_MINSURF_P_vr(1:nlevdecomp_full,0:nsoilorder))
     allocate( decompmicc_patch_vr (1:nlevdecomp_full,0:mxpft))
     allocate( VMAX_PTASE(0:mxpft))
-    allocate( i_vc               (0:mxpft) ) 
-    allocate( s_vc               (0:mxpft) ) 
+    allocate( i_vc               (0:mxpft) )
+    allocate( s_vc               (0:mxpft) )
     allocate( nsc_rtime          (0:mxpft) )
     allocate( pinit_beta1        (0:nsoilorder))
     allocate( pinit_beta2        (0:nsoilorder))
@@ -553,22 +557,22 @@ contains
     allocate( VMAX_NFIX          (0:mxpft) )
     allocate( KM_NFIX            (0:mxpft) )
     ! new stoichiometry
-    allocate( leafcn_obs         (0:mxpft) )   
-    allocate( frootcn_obs        (0:mxpft) )   
+    allocate( leafcn_obs         (0:mxpft) )
+    allocate( frootcn_obs        (0:mxpft) )
     allocate( livewdcn_obs       (0:mxpft) )
-    allocate( deadwdcn_obs       (0:mxpft) )      
-    allocate( leafcp_obs         (0:mxpft) )   
-    allocate( frootcp_obs        (0:mxpft) )   
+    allocate( deadwdcn_obs       (0:mxpft) )
+    allocate( leafcp_obs         (0:mxpft) )
+    allocate( frootcp_obs        (0:mxpft) )
     allocate( livewdcp_obs       (0:mxpft) )
-    allocate( deadwdcp_obs       (0:mxpft) ) 
-    allocate( leafcn_obs_flex         (0:mxpft,1:2) )   
-    allocate( frootcn_obs_flex        (0:mxpft,1:2) )   
+    allocate( deadwdcp_obs       (0:mxpft) )
+    allocate( leafcn_obs_flex         (0:mxpft,1:2) )
+    allocate( frootcn_obs_flex        (0:mxpft,1:2) )
     allocate( livewdcn_obs_flex       (0:mxpft,1:2) )
-    allocate( deadwdcn_obs_flex       (0:mxpft,1:2) )      
-    allocate( leafcp_obs_flex         (0:mxpft,1:2) )   
-    allocate( frootcp_obs_flex        (0:mxpft,1:2) )   
+    allocate( deadwdcn_obs_flex       (0:mxpft,1:2) )
+    allocate( leafcp_obs_flex         (0:mxpft,1:2) )
+    allocate( frootcp_obs_flex        (0:mxpft,1:2) )
     allocate( livewdcp_obs_flex       (0:mxpft,1:2) )
-    allocate( deadwdcp_obs_flex       (0:mxpft,1:2) ) 
+    allocate( deadwdcp_obs_flex       (0:mxpft,1:2) )
     allocate( vcmax_np1          (0:mxpft) )
     allocate( vcmax_np2          (0:mxpft) )
     allocate( vcmax_np3          (0:mxpft) )
@@ -600,8 +604,12 @@ contains
     allocate( gcbr_p             (0:mxpft) )
     allocate( gcbr_q             (0:mxpft) )
 
-   ! NGEE arctic
-    allocate( bend_parm          (0:mxpft) )
+   ! NGEE arctic snow-vegetation interactions
+    allocate( bendresist         (0:mxpft) )
+    allocate( vegshape           (0:mxpft) )
+    allocate( stocking           (0:mxpft) )
+    allocate( taper              (0:mxpft) )
+
     ! Set specific vegetation type values
 
     if (masterproc) then
@@ -612,7 +620,7 @@ contains
     call ncd_inqdid(ncid,'pft',dimid)
     call ncd_inqdlen(ncid,dimid,npft)
 
-    call ncd_io('pftname',pftname, 'read', ncid, readvar=readv, posNOTonfile=.true.) 
+    call ncd_io('pftname',pftname, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('z0mr',z0mr, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
@@ -704,16 +712,16 @@ contains
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('fr_flab',fr_flab, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fr_fcel',fr_fcel, 'read', ncid, readvar=readv, posNOTonfile=.true.)    
+    call ncd_io('fr_fcel',fr_fcel, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fr_flig',fr_flig, 'read', ncid, readvar=readv, posNOTonfile=.true.)    
+    call ncd_io('fr_flig',fr_flig, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('leaf_long',leaf_long, 'read', ncid, readvar=readv, posNOTonfile=.true.)    
+    call ncd_io('leaf_long',leaf_long, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('froot_long',froot_long, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if (.not. readv) froot_long = leaf_long
     !if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('evergreen',evergreen, 'read', ncid, readvar=readv, posNOTonfile=.true.)    
+    call ncd_io('evergreen',evergreen, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('stress_decid',stress_decid, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
@@ -750,95 +758,95 @@ contains
        call ncd_io('rootprof_beta',rootprof_beta, 'read', ncid, readvar=readv, posNOTonfile=.true.)
        if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     end if
-    call ncd_io('pconv',pconv, 'read', ncid, readvar=readv)  
+    call ncd_io('pconv',pconv, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('pprod10',pprod10, 'read', ncid, readvar=readv)  
+    call ncd_io('pprod10',pprod10, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('pprodharv10',pprodharv10, 'read', ncid, readvar=readv)  
+    call ncd_io('pprodharv10',pprodharv10, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('pprod100',pprod100, 'read', ncid, readvar=readv)  
+    call ncd_io('pprod100',pprod100, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('graincn',graincn, 'read', ncid, readvar=readv)  
+    call ncd_io('graincn',graincn, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('graincp',graincp, 'read', ncid, readvar=readv)  
+    call ncd_io('graincp',graincp, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('mxtmp',mxtmp, 'read', ncid, readvar=readv)  
+    call ncd_io('mxtmp',mxtmp, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('baset',baset, 'read', ncid, readvar=readv)  
+    call ncd_io('baset',baset, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('declfact',declfact, 'read', ncid, readvar=readv)  
+    call ncd_io('declfact',declfact, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('bfact',bfact, 'read', ncid, readvar=readv)  
+    call ncd_io('bfact',bfact, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('aleaff',aleaff, 'read', ncid, readvar=readv)  
+    call ncd_io('aleaff',aleaff, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('arootf',arootf, 'read', ncid, readvar=readv)  
+    call ncd_io('arootf',arootf, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('astemf',astemf, 'read', ncid, readvar=readv)  
+    call ncd_io('astemf',astemf, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('arooti',arooti, 'read', ncid, readvar=readv)  
+    call ncd_io('arooti',arooti, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fleafi',fleafi, 'read', ncid, readvar=readv)  
+    call ncd_io('fleafi',fleafi, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('allconsl',allconsl, 'read', ncid, readvar=readv)  
+    call ncd_io('allconsl',allconsl, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('allconss',allconss, 'read', ncid, readvar=readv)  
+    call ncd_io('allconss',allconss, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('crop',crop, 'read', ncid, readvar=readv)  
+    call ncd_io('crop',crop, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('irrigated',irrigated, 'read', ncid, readvar=readv)  
+    call ncd_io('irrigated',irrigated, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('ztopmx',ztopmx, 'read', ncid, readvar=readv)  
+    call ncd_io('ztopmx',ztopmx, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('laimx',laimx, 'read', ncid, readvar=readv)  
+    call ncd_io('laimx',laimx, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('gddmin',gddmin, 'read', ncid, readvar=readv)  
+    call ncd_io('gddmin',gddmin, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('hybgdd',hybgdd, 'read', ncid, readvar=readv)  
+    call ncd_io('hybgdd',hybgdd, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('lfemerg',lfemerg, 'read', ncid, readvar=readv)  
+    call ncd_io('lfemerg',lfemerg, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('grnfill',grnfill, 'read', ncid, readvar=readv)  
+    call ncd_io('grnfill',grnfill, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('mxmat',mxmat, 'read', ncid, readvar=readv)  
+    call ncd_io('mxmat',mxmat, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('cc_leaf', cc_leaf, 'read', ncid, readvar=readv)  
+    call ncd_io('cc_leaf', cc_leaf, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('cc_lstem',cc_lstem, 'read', ncid, readvar=readv)  
+    call ncd_io('cc_lstem',cc_lstem, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('cc_dstem',cc_dstem, 'read', ncid, readvar=readv)  
+    call ncd_io('cc_dstem',cc_dstem, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('cc_other',cc_other, 'read', ncid, readvar=readv)  
+    call ncd_io('cc_other',cc_other, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_leaf', fm_leaf, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_leaf', fm_leaf, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_lstem',fm_lstem, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_lstem',fm_lstem, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_dstem',fm_dstem, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_dstem',fm_dstem, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_other',fm_other, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_other',fm_other, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_root', fm_root, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_root', fm_root, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_lroot',fm_lroot, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_lroot',fm_lroot, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fm_droot',fm_droot, 'read', ncid, readvar=readv)  
+    call ncd_io('fm_droot',fm_droot, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fsr_pft', fsr_pft, 'read', ncid, readvar=readv)  
+    call ncd_io('fsr_pft', fsr_pft, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('fd_pft',  fd_pft, 'read', ncid, readvar=readv)  
+    call ncd_io('fd_pft',  fd_pft, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('planting_temp',planttemp, 'read', ncid, readvar=readv)  
+    call ncd_io('planting_temp',planttemp, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('min_planting_temp',minplanttemp, 'read', ncid, readvar=readv)  
+    call ncd_io('min_planting_temp',minplanttemp, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('min_NH_planting_date',mnNHplantdate, 'read', ncid, readvar=readv)  
+    call ncd_io('min_NH_planting_date',mnNHplantdate, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('min_SH_planting_date',mnSHplantdate, 'read', ncid, readvar=readv)  
+    call ncd_io('min_SH_planting_date',mnSHplantdate, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('max_NH_planting_date',mxNHplantdate, 'read', ncid, readvar=readv)  
+    call ncd_io('max_NH_planting_date',mxNHplantdate, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
-    call ncd_io('max_SH_planting_date',mxSHplantdate, 'read', ncid, readvar=readv)  
+    call ncd_io('max_SH_planting_date',mxSHplantdate, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
 
     if (nu_com .ne. 'RD' ) then
@@ -846,40 +854,40 @@ contains
         ! These are soil parameters and used for both FATES and big leaf ELM
         call ncd_io('VMAX_MINSURF_P_vr',VMAX_MINSURF_P_vr, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order VMAX_MINSURF_P_vr'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_MINSURF_P_vr',KM_MINSURF_P_vr, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_MINSURF_P_vr',KM_MINSURF_P_vr, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in soil order KM_MINSURF_P_vr'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_DECOMP_NH4',KM_DECOMP_NH4, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_DECOMP_NH4',KM_DECOMP_NH4, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_DECOMP_NH4'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_DECOMP_NO3',KM_DECOMP_NO3, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_DECOMP_NO3',KM_DECOMP_NO3, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_DECOMP_NO3'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_DECOMP_P',KM_DECOMP_P, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_DECOMP_P',KM_DECOMP_P, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_DECOMP_P'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_NIT',KM_NIT, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_NIT',KM_NIT, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_NIT'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_DEN',KM_DEN, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_DEN',KM_DEN, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_DEN'//errMsg(__FILE__, __LINE__))
         call ncd_io('pinit_beta1',pinit_beta1, 'read', ncid, readvar=readv)
         if ( .not. readv ) pinit_beta1(:) = 0.5_r8
         call ncd_io('pinit_beta2',pinit_beta2, 'read', ncid, readvar=readv)
         if ( .not. readv ) pinit_beta2(:) = 0.1_r8
-        
+
         if(.not.use_fates) then
-        
-        call ncd_io('VMAX_PLANT_NH4',VMAX_PLANT_NH4, 'read', ncid, readvar=readv)  
+
+        call ncd_io('VMAX_PLANT_NH4',VMAX_PLANT_NH4, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft VMAX_PLANT_NH4'//errMsg(__FILE__, __LINE__))
-        call ncd_io('VMAX_PLANT_NO3',VMAX_PLANT_NO3, 'read', ncid, readvar=readv)  
+        call ncd_io('VMAX_PLANT_NO3',VMAX_PLANT_NO3, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft VMAX_PLANT_NO3'//errMsg(__FILE__, __LINE__))
-        call ncd_io('VMAX_PLANT_P',VMAX_PLANT_P, 'read', ncid, readvar=readv)  
+        call ncd_io('VMAX_PLANT_P',VMAX_PLANT_P, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft VMAX_PLANT_P'//errMsg(__FILE__, __LINE__))
-        
-        call ncd_io('KM_PLANT_NH4',KM_PLANT_NH4, 'read', ncid, readvar=readv)  
+
+        call ncd_io('KM_PLANT_NH4',KM_PLANT_NH4, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft KM_PLANT_NH4'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_PLANT_NO3',KM_PLANT_NO3, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_PLANT_NO3',KM_PLANT_NO3, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft KM_PLANT_NO3'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_PLANT_P',KM_PLANT_P, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_PLANT_P',KM_PLANT_P, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft KM_PLANT_P'//errMsg(__FILE__, __LINE__))
-        
-        call ncd_io('decompmicc_patch_vr',decompmicc_patch_vr, 'read', ncid, readvar=readv)  
+
+        call ncd_io('decompmicc_patch_vr',decompmicc_patch_vr, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft decompmicc_patch_vr'//errMsg(__FILE__, __LINE__))
         call ncd_io('alpha_nfix',alpha_nfix, 'read', ncid, readvar=readv)
         if ( .not. readv ) alpha_nfix(:)=0._r8
@@ -893,19 +901,19 @@ contains
         if ( .not. readv ) ccost_ptase(:)=0._r8
         call ncd_io('ncost_ptase',ncost_ptase, 'read', ncid, readvar=readv)
         if ( .not. readv ) ncost_ptase(:)=0._r8
-        call ncd_io('VMAX_NFIX',VMAX_NFIX, 'read', ncid, readvar=readv)  
+        call ncd_io('VMAX_NFIX',VMAX_NFIX, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in VMAX_NFIX'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_NFIX',KM_NFIX, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_NFIX',KM_NFIX, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_NFIX'//errMsg(__FILE__, __LINE__))
-        call ncd_io('VMAX_PTASE',VMAX_PTASE, 'read', ncid, readvar=readv)  
+        call ncd_io('VMAX_PTASE',VMAX_PTASE, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in VMAX_PTASE'//errMsg(__FILE__, __LINE__))
-        call ncd_io('KM_PTASE',KM_PTASE, 'read', ncid, readvar=readv)  
+        call ncd_io('KM_PTASE',KM_PTASE, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in KM_PTASE'//errMsg(__FILE__, __LINE__))
-        call ncd_io('lamda_ptase',lamda_ptase, 'read', ncid, readvar=readv)  
+        call ncd_io('lamda_ptase',lamda_ptase, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in lamda_ptase'//errMsg(__FILE__, __LINE__))
-        call ncd_io('i_vc',i_vc, 'read', ncid, readvar=readv)  
+        call ncd_io('i_vc',i_vc, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in i_vc'//errMsg(__FILE__, __LINE__))
-        call ncd_io('s_vc',s_vc, 'read', ncid, readvar=readv)  
+        call ncd_io('s_vc',s_vc, 'read', ncid, readvar=readv)
         if ( .not. readv ) call endrun(msg=' ERROR: error in reading in s_vc'//errMsg(__FILE__, __LINE__))
         call ncd_io('nsc_rtime',nsc_rtime, 'read', ncid, readvar=readv)
         if ( .not. readv ) nsc_rtime(:) = 1.0_r8
@@ -967,13 +975,13 @@ contains
     call ncd_io('fnr', fnr, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('act25', act25, 'read', ncid, readvar=readv, posNOTonfile=.true.)
-    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__)) 
+    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('kcha', kcha, 'read', ncid, readvar=readv, posNOTonfile=.true.)
-    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__)) 
+    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('koha', koha, 'read', ncid, readvar=readv, posNOTonfile=.true.)
-    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__)) 
+    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('cpha', cpha, 'read', ncid, readvar=readv, posNOTonfile=.true.)
-    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))  
+    if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('vcmaxha', vcmaxha, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv) call endrun(msg='ERROR:  error in reading in pft data'//errMsg(__FILE__,__LINE__))
     call ncd_io('jmaxha', jmaxha, 'read', ncid, readvar=readv, posNOTonfile=.true.)
@@ -1015,18 +1023,28 @@ contains
     if ( .not. readv ) gcbr_p(:) = 0._r8
     call ncd_io('gcbr_q',gcbr_q, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if ( .not. readv ) gcbr_q(:) = 0._r8
-       
-    call ncd_io('mergetoclmpft', mergetoelmpft, 'read', ncid, readvar=readv)  
+
+    call ncd_io('mergetoclmpft', mergetoelmpft, 'read', ncid, readvar=readv)
     if ( .not. readv ) then
        do i = 0, mxpft
           mergetoelmpft(i) = i
        end do
     end if
 
-    ! new NGEE parameters:
-    call ncd_io('bend_parm', bend_parm, 'read', ncid, readvar=readv, posNOTonfile=.true.)
-    if (.not. readv ) bend_parm(:) = 1._r8   ! set to 1 if not on file - by default: no change.
-
+    ! NGEE-Arctic snow-vegetation parameters
+    call ncd_io('bendresist', bendresist, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if (.not. readv ) bendresist(:) = 1._r8
+    call ncd_io('vegshape', vegshape, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if (.not. readv ) vegshape(:) = 1._r8
+    call ncd_io('stocking', stocking, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if (.not. readv ) stocking(:) = 1000._r8
+    call ncd_io('taper', taper, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if (.not. readv ) then
+      taper(:) = 200._r8
+      do i = 0, npft - 1
+        if (woody(i) == 2) taper(i) = 10.0_r8 ! shrubs
+      end do
+    end if
 
 
     call ncd_pio_closefile(ncid)
@@ -1034,7 +1052,7 @@ contains
     do i = 0, mxpft
 
        if(.not. use_crop .and. i > mxpft_nc) EXIT ! exit the do loop
-       
+
        ! (FATES-INTERF) Later, depending on how the team plans to structure the crop model
        ! or other modules that co-exist while FATES is on, we may want to preserve these pft definitions
        ! on non-fates columns.  For now, they are incompatible, and this check is warranted (rgk 04-2017)

--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -1036,12 +1036,25 @@ contains
     if (.not. readv ) bendresist(:) = 1._r8
     call ncd_io('vegshape', vegshape, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if (.not. readv ) vegshape(:) = 1._r8
+   ! check validity
+    do i = 0, npft -1
+      if (bendresist(i) .gt. 1.0_r8 .or. bendresist(i) .le. 0._r8) then
+         call endrun(msg="Non-physical selection of bendresist parameter, set between 0 and 1"//errMsg(__FILE__, __LINE__))
+      end if
+      if (vegshape(i) .gt. 2.0_r8 .or. vegshape(i) .le. 0_r8) then
+         call endrun(msg="Non-physical selection of vegshape parameter, set between 0 and 2"//errMsg(__FILE__, __LINE__))
+      end if
+   end do
     call ncd_io('stocking', stocking, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if (.not. readv ) stocking(:) = 1000._r8
+    ! convert from stems/ha -> stems/m2
+    do i = 0, npft
+      stocking(i) = stocking(i) / 10000._r8
+    end do 
     call ncd_io('taper', taper, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if (.not. readv ) then
       taper(:) = 200._r8
-      do i = 0, npft - 1
+      do i = 0, npft
         ! RPF 240331 - need to revisit this section when integrating with IM4,
         ! to make consistent with attempt to remove hard-coded pft numbers.
         if (i >= nbrdlf_evr_shrub .and. i <= nbrdlf_dcd_brl_shrub) taper(i) = 10.0_r8 ! shrubs

--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -302,6 +302,8 @@ module pftvarcon
   real(r8), allocatable :: gcbc_q(:)           !effectiveness of surface cover in reducing runoff-driven erosion
   real(r8), allocatable :: gcbr_p(:)           !effectiveness of roots in reducing rainfall-driven erosion
   real(r8), allocatable :: gcbr_q(:)           !effectiveness of roots in reducing runoff-driven erosion
+   ! NGEE Arctic shrub bending 
+  real(r8), allocatable :: bend_parm(:)        ! parameter that describes the "stiffness" of shrub branches (Sturm et al. 2005, Liston and Hiemstra 2011)
 
   !
   ! !PUBLIC MEMBER FUNCTIONS:
@@ -598,6 +600,8 @@ contains
     allocate( gcbr_p             (0:mxpft) )
     allocate( gcbr_q             (0:mxpft) )
 
+   ! NGEE arctic
+    allocate( bend_parm          (0:mxpft) )
     ! Set specific vegetation type values
 
     if (masterproc) then
@@ -1018,6 +1022,10 @@ contains
           mergetoelmpft(i) = i
        end do
     end if
+
+    ! new NGEE parameters:
+    call ncd_io('bend_parm', bend_parm, 'read', ncid, readvar=readv, posNOTonfile=.true.)
+    if (.not. readv ) bend_parm(:) = 1._r8   ! set to 1 if not on file - by default: no change.
 
 
 


### PR DESCRIPTION
Merges changes made to VegStructUpdateMod.F90 that do the following:
1) remove hard-coded values of taper and stocking parameters, and now allow them to vary by PFT based on what is provided on clm_params file.
2) Allows for the rate at which vegetation canopies are buried with snow to vary from a linear relationship with snow depth. Two new parameters are added to achieve this, both variable by pft:
- bendresist, which is meant to represent effects from snow loading on branches, biophysical freeze bending responses, and (implicitly) differential loading of snow into vegetation. Values of 1 correspond to stiff branches (e.g., sagebrush) that do not bend in snow; lower values correspond to other vegetation groups such as Arctic shrubs.
- vegshape, which is meant to account for variations in width of the canopy crown with height. 

By default: taper and stocking parameters are now set into pftvarcon.F90 to their original hard-coded values unless they are provided on a params file, bendresist and vegshape = 1 (reducing new expression of LAI burial to the existing linear relationship) unless different values are put on the input file. 