### PR TITLE
Implement thermodynamics for melting of excess ice

### DIFF
--- a/components/elm/src/biogeophys/ActiveLayerMod.F90
+++ b/components/elm/src/biogeophys/ActiveLayerMod.F90
@@ -4,6 +4,11 @@ module ActiveLayerMod
   ! !DESCRIPTION:
   ! Module holding routines for calculation of active layer dynamics
   !
+  ! NOTE (Implementation Update): Excess ice melting is now handled thermodynamically
+  ! in PhaseChange_beta (SoilTemperatureMod.F90) rather than geometrically in this module.
+  ! The geometric melting approach and associated frac_melted tracking have been removed.
+  ! Active layer depth calculations remain unchanged for diagnostic purposes.
+  !
   ! !USES:
   use shr_kind_mod    , only : r8 => shr_kind_r8
   use shr_const_mod   , only : SHR_CONST_TKFRZ
@@ -88,8 +93,7 @@ contains
          rmax                 =>    col_ws%iwp_microrel                  ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon microtopographic relief (m)
          vexc                 =>    col_ws%iwp_exclvol                   ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon excluded volume (m)
          ddep                 =>    col_ws%iwp_ddep                      ,      & ! Output:  [real(r8) (:)   ]  ice wedge polygon depression depth (m)
-         subsidence           =>    col_ws%iwp_subsidence                ,      & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
-         frac_melted          =>    col_ws%frac_melted                          & ! Input/output:[real(r8)(:)]  fraction of layer that has ever melted (-)
+         subsidence           =>    col_ws%iwp_subsidence                       & ! Input/output:[real(r8)(:)]  ice wedge polygon subsidence (m)
          )
 
       ! on a set annual timestep, update annual maxima
@@ -180,62 +184,72 @@ contains
                altmax_1989_indx(c) = altmax_indx(c)
             endif
 
-           ! update subsidence based on change in ALT
-           ! melt_profile stores the amount of excess_ice
-           ! melted in this timestep.
-           ! note that this may cause some unexpected results
-           ! for taliks
-
-           ! initialize melt_profile as zero
-           melt_profile(:) = 0._r8
-
-           do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
-              if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
-                melt_profile(j) = 0.0_r8
-              else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer
-                ! need to check to see if the active layer thickness is is actually
-                ! in this layer (and not between the midpoint of j_frz and bottom interface
-                ! or else inferred melt will be negative
-                ! also note: only have ice to melt if alt has never been this deep, otherwise
-                ! ice will continue to be removed each time step the alt remains in this layer
-                if ((alt(c)-zisoi(j-1)) .ge. 0._r8 .and. (alt(c) .eq. altmax_ever(c)) .and. (frac_melted(c,j) .lt. 1._r8)) then
-                  orig_excess = (1._r8/(1._r8-frac_melted(c,j))) * excess_ice(c,j)
-                  old_mfrac = frac_melted(c,j)
-                  ! update frac melted
-                  frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zisoi(j-1))/dzsoi(j)),1._r8)
-                  melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
-                  excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
-                else
-                  melt_profile(j) = 0._r8 ! no melt
-                end if
-              else if (j .eq. k_frz) then
-                if (alt(c) .eq. altmax_ever(c) .and. (frac_melted(c,j) .lt. 1._r8)) then
-                  orig_excess = (1._r8/(1._r8 - frac_melted(c,j))) * excess_ice(c,j)
-                  old_mfrac = frac_melted(c,j)
-                  ! update frac_melted:
-                  frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zsoi(j-1))/dzsoi(j)),1._r8)
-                  ! remove ice, only if alt has never been this deep before:
-                  melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
-                  excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
-                else
-                  melt_profile(j) = 0._r8
-                end if
-              else !
-                 melt_profile(j) = excess_ice(c,j)
-                 ! remove melted excess ice
-                 excess_ice(c,j) = 0._r8
-              end if
-              ! calculate subsidence at this layer:
-              melt_profile(j) = melt_profile(j) * dzsoi(j)
-           end do
-
-           ! subsidence is integral of melt profile:
-           if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
-              subsidence(c) = subsidence(c) + sum(melt_profile)
-           end if
-
-           ! limit subsidence to 0.4 m
-           subsidence(c) = min(0.4_r8, subsidence(c))
+           ! ============================================================================
+           ! NOTE: The following geometric melting approach has been replaced by
+           ! thermodynamically-controlled melting in PhaseChange_beta (SoilTemperatureMod.F90).
+           ! Excess ice melting and subsidence are now calculated based on energy balance
+           ! in the phase change routine. This code is retained for reference but is no longer active.
+           ! ============================================================================
+           !
+           ! ! update subsidence based on change in ALT
+           ! ! melt_profile stores the amount of excess_ice
+           ! ! melted in this timestep.
+           ! ! note that this may cause some unexpected results
+           ! ! for taliks
+           !
+           ! ! initialize melt_profile as zero
+           ! melt_profile(:) = 0._r8
+           !
+           ! do j = nlevgrnd,1,-1 ! note, this will go from bottom to top
+           !    if (j .gt. k_frz + 1) then ! all layers below k_frz + 1 remain frozen
+           !      melt_profile(j) = 0.0_r8
+           !    else if (j .eq. k_frz + 1) then ! first layer below the 'thawed' layer
+           !      ! need to check to see if the active layer thickness is is actually
+           !      ! in this layer (and not between the midpoint of j_frz and bottom interface
+           !      ! or else inferred melt will be negative
+           !      ! also note: only have ice to melt if alt has never been this deep, otherwise
+           !      ! ice will continue to be removed each time step the alt remains in this layer
+           !      if ((alt(c)-zisoi(j-1)) .ge. 0._r8 .and. (alt(c) .eq. altmax_ever(c)) .and. (frac_melted(c,j) .lt. 1._r8)) then
+           !        orig_excess = (1._r8/(1._r8-frac_melted(c,j))) * excess_ice(c,j)
+           !        old_mfrac = frac_melted(c,j)
+           !        ! update frac melted
+           !        frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zisoi(j-1))/dzsoi(j)),1._r8)
+           !        melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
+           !        excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
+           !      else
+           !        melt_profile(j) = 0._r8 ! no melt
+           !      end if
+           !    else if (j .eq. k_frz) then
+           !      if (alt(c) .eq. altmax_ever(c) .and. (frac_melted(c,j) .lt. 1._r8)) then
+           !        orig_excess = (1._r8/(1._r8 - frac_melted(c,j))) * excess_ice(c,j)
+           !        old_mfrac = frac_melted(c,j)
+           !        ! update frac_melted:
+           !        frac_melted(c,j) = min(max(frac_melted(c,j), (alt(c)-zsoi(j-1))/dzsoi(j)),1._r8)
+           !        ! remove ice, only if alt has never been this deep before:
+           !        melt_profile(j) = orig_excess*(frac_melted(c,j) - old_mfrac)
+           !        excess_ice(c,j) = excess_ice(c,j) - melt_profile(j)
+           !      else
+           !        melt_profile(j) = 0._r8
+           !      end if
+           !    else !
+           !       melt_profile(j) = excess_ice(c,j)
+           !       ! remove melted excess ice
+           !       excess_ice(c,j) = 0._r8
+           !    end if
+           !    ! calculate subsidence at this layer:
+           !    melt_profile(j) = melt_profile(j) * dzsoi(j)
+           ! end do
+           !
+           ! ! NOTE: Subsidence now calculated in PhaseChange_beta based on actual
+           ! ! excess ice mass change from energy balance
+           ! !
+           ! ! subsidence is integral of melt profile:
+           ! if ((year .ge. 1989) .and. (altmax_ever(c) .ge. altmax_1989(c))) then
+           !    subsidence(c) = subsidence(c) + sum(melt_profile)
+           ! end if
+           !
+           ! ! limit subsidence to 0.4 m
+           ! subsidence(c) = min(0.4_r8, subsidence(c))
 
            ! update ice wedge polygon microtopographic parameters if in polygonal ground
            if (lun_pp%ispolygon(col_pp%landunit(c))) then

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -237,6 +237,7 @@ contains
           qflx_to_downhill           =>    col_wf%qflx_to_downhill        , & ! Input:  [real(r8) (:)   ]  sent to downhill topounit
           qflx_h2osfc_surf           =>    col_wf%qflx_h2osfc_surf        , & ! Input:  [real(r8) (:)   ]  surface water runoff (mm/s)
           qflx_snow_melt             =>    col_wf%qflx_snow_melt          , & ! Input:  [real(r8) (:)   ]  snow melt (net)
+          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:,:)   ]  excess ice melt (kg/m2/s)
           qflx_surf                  =>    col_wf%qflx_surf               , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)
           qflx_qrgwl                 =>    col_wf%qflx_qrgwl              , & ! Input:  [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes
           qflx_drain                 =>    col_wf%qflx_drain              , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)
@@ -436,6 +437,7 @@ contains
              write(iulog,*)'qflx_glcice_melt           = ',qflx_glcice_melt(indexc)
              write(iulog,*)'qflx_glcice_frz            = ',qflx_glcice_frz(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
+             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc,:)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -9,7 +9,7 @@ module BalanceCheckMod
   use shr_log_mod        , only : errMsg => shr_log_errMsg
   use decompMod          , only : bounds_type
   use abortutils         , only : endrun
-  use elm_varctl         , only : iulog, use_var_soil_thick, use_firn_percolation_and_compaction
+  use elm_varctl         , only : iulog, use_var_soil_thick, use_firn_percolation_and_compaction, use_polygonal_tundra
   use elm_varcon         , only : namep, namec
   use GetGlobalValuesMod , only : GetGlobalIndex
   use atm2lndType        , only : atm2lnd_type
@@ -69,7 +69,7 @@ contains
     type(soilhydrology_type)  , intent(inout) :: soilhydrology_vars
     !
     ! !LOCAL VARIABLES:
-    integer :: c, p, f, j, fc                  ! indices
+    integer :: c, p, f, j, fc, l                 ! indices
     real(r8):: h2osoi_vol
     !-----------------------------------------------------------------------
 
@@ -79,6 +79,7 @@ contains
          h2osfc                 =>    col_ws%h2osfc                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
          h2osno                 =>    col_ws%h2osno                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice             =>    col_ws%h2osoi_ice             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice             =>    col_ws%excess_ice             , & ! Input:  [real(r8) (:,:) ] excess ice (kg/m2)
          h2osoi_liq             =>    col_ws%h2osoi_liq             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          total_plant_stored_h2o =>    col_ws%total_plant_stored_h2o , & ! Input: [real(r8) (:) dynamic water stored in plants
          zwt                    =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)
@@ -115,10 +116,15 @@ contains
       do j = 1, nlevgrnd
          do f = 1, num_nolakec
             c = filter_nolakec(f)
+            l = col_pp%landunit(c)
             if ((col_pp%itype(c) == icol_sunwall .or. col_pp%itype(c) == icol_shadewall &
                  .or. col_pp%itype(c) == icol_roof) .and. j > nlevurb) then
             else
-               begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j) + excess_ice(c,j)
+               else
+                  begwb(c) = begwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               endif 
             end if
          end do
       end do
@@ -237,7 +243,7 @@ contains
           qflx_to_downhill           =>    col_wf%qflx_to_downhill        , & ! Input:  [real(r8) (:)   ]  sent to downhill topounit
           qflx_h2osfc_surf           =>    col_wf%qflx_h2osfc_surf        , & ! Input:  [real(r8) (:)   ]  surface water runoff (mm/s)
           qflx_snow_melt             =>    col_wf%qflx_snow_melt          , & ! Input:  [real(r8) (:)   ]  snow melt (net)
-          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:,:)   ]  excess ice melt (kg/m2/s)
+          qflx_exice_melt             =>   col_wf%qflx_exice_melt         , & ! Input:  [real(r8) (:)   ]  excess ice melt (mm/s)
           qflx_surf                  =>    col_wf%qflx_surf               , & ! Input:  [real(r8) (:)   ]  surface runoff (mm H2O /s)
           qflx_qrgwl                 =>    col_wf%qflx_qrgwl              , & ! Input:  [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes
           qflx_drain                 =>    col_wf%qflx_drain              , & ! Input:  [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)
@@ -415,7 +421,7 @@ contains
           else if (abs(errh2o(indexc)) > 1.e-4_r8 .and. (nstep > 2) ) then
 
              write(iulog,*)'elm model is stopping - error is greater than 1e-4 (mm)'
-             write(iulog,*)'colum number               = ',col_pp%gridcell(indexc)
+             write(iulog,*)'column number              = ',col_pp%gridcell(indexc)
              write(iulog,*)'nstep                      = ',nstep
              write(iulog,*)'errh2o                     = ',errh2o(indexc)
              write(iulog,*)'forc_rain                  = ',forc_rain_col(indexc)
@@ -437,7 +443,7 @@ contains
              write(iulog,*)'qflx_glcice_melt           = ',qflx_glcice_melt(indexc)
              write(iulog,*)'qflx_glcice_frz            = ',qflx_glcice_frz(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
-             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc,:)
+             write(iulog,*)'qflx_exice_melt            = ',qflx_exice_melt(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)
@@ -813,6 +819,7 @@ contains
          h2osfc                    =>    col_ws%h2osfc                 , & ! Input:  [real(r8) (:)   ]  surface water (mm)
          h2osno                    =>    col_ws%h2osno                 , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_ice                =>    col_ws%h2osoi_ice             , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice                =>    col_ws%excess_ice             , & ! Input:  [real(r8) (:,:) ]  excess ice (if using polygonal tundra)
          h2osoi_liq                =>    col_ws%h2osoi_liq             , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          total_plant_stored_h2o    =>    col_ws%total_plant_stored_h2o , & ! Input:  [real(r8) (:)   ]  dynamic water stored in plants
          zwt                       =>    soilhydrology_vars%zwt_col                 , & ! Input:  [real(r8) (:)   ]  water table depth (m)

--- a/components/elm/src/biogeophys/EnergyFluxType.F90
+++ b/components/elm/src/biogeophys/EnergyFluxType.F90
@@ -47,6 +47,7 @@ module EnergyFluxType
      real(r8), pointer :: eflx_snomelt_col        (:)   ! col snow melt heat flux (W/m**2)
      real(r8), pointer :: eflx_snomelt_r_col      (:)   ! col rural snow melt heat flux (W/m**2)
      real(r8), pointer :: eflx_snomelt_u_col      (:)   ! col urban snow melt heat flux (W/m**2)
+     real(r8), pointer :: eflx_exice_melt_col     (:)   ! col excess ice melt latent heat flux (W/m**2)
      real(r8), pointer :: eflx_gnet_patch         (:)   ! patch net heat flux into ground  (W/m**2)
      real(r8), pointer :: eflx_grnd_lake_patch    (:)   ! patch net heat flux into lake / snow surface, excluding light transmission (W/m**2)
      real(r8), pointer :: eflx_dynbal_grc         (:)   ! grc dynamic land cover change conversion energy flux (W/m**2)
@@ -210,6 +211,7 @@ contains
     allocate( this%eflx_snomelt_col        (begc:endc))             ; this%eflx_snomelt_col        (:)   = spval 
     allocate( this%eflx_snomelt_r_col      (begc:endc))             ; this%eflx_snomelt_r_col      (:)   = spval 
     allocate( this%eflx_snomelt_u_col      (begc:endc))             ; this%eflx_snomelt_u_col      (:)   = spval 
+    allocate( this%eflx_exice_melt_col     (begc:endc))             ; this%eflx_exice_melt_col     (:)   = spval 
     allocate( this%eflx_fgr12_col          (begc:endc))             ; this%eflx_fgr12_col          (:)   = spval 
     allocate( this%eflx_fgr_col            (begc:endc, 1:nlevgrnd)) ; this%eflx_fgr_col            (:,:) = spval 
     allocate( this%eflx_building_heat_col  (begc:endc))             ; this%eflx_building_heat_col  (:)   = spval 

--- a/components/elm/src/biogeophys/HydrologyDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyDrainageMod.F90
@@ -50,7 +50,7 @@ contains
     use landunit_varcon  , only : istice, istwet, istsoil, istice_mec, istcrop, istice
     use column_varcon    , only : icol_roof, icol_road_imperv, icol_road_perv, icol_sunwall, icol_shadewall
     use elm_varcon       , only : denh2o, denice, secspday, frac_to_downhill
-    use elm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr
+    use elm_varctl       , only : glc_snow_persistence_max_days, use_vichydro, use_betr, use_polygonal_tundra
     !use domainMod        , only : ldomain
     use elm_varsur         , only : f_surf
     use TopounitType       , only : top_pp
@@ -102,6 +102,7 @@ contains
          begwb                  => col_ws%begwb                  , & ! Input:  [real(r8) (:)   ]  water mass begining of the time step
          endwb                  => col_ws%endwb                  , & ! Output: [real(r8) (:)   ]  water mass end of the time step
          h2osoi_ice             => col_ws%h2osoi_ice             , & ! Output: [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice             => col_ws%excess_ice             , & ! Output? RPF [real(r8) (:,:) ] excess ice (kg/m2)
          h2osoi_liq             => col_ws%h2osoi_liq             , & ! Output: [real(r8) (:,:) ]  liquid water (kg/m2)
          h2osoi_vol             => col_ws%h2osoi_vol             , & ! Output: [real(r8) (:,:) ]  volumetric soil water (0<=h2osoi_vol<=watsat) [m3/m3]
          snow_persistence       => col_ws%snow_persistence       , & ! Output: [real(r8) (:)   ]  counter for length of time snow-covered
@@ -187,13 +188,20 @@ contains
       do j = 1, nlevgrnd
          do fc = 1, num_nolakec
             c = filter_nolakec(fc)
+            l = col_pp%landunit(c)
             if ((ctype(c) == icol_sunwall .or. ctype(c) == icol_shadewall &
                  .or. ctype(c) == icol_roof) .and. j > nlevurb) then
 
             else
-               endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
-               h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
-               h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j) + excess_ice(c,j)
+                  h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+                  h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j) + excess_ice(c,j)
+               else
+                  endwb(c) = endwb(c) + h2osoi_ice(c,j) + h2osoi_liq(c,j)
+                  h2osoi_liq_depth_intg(c) = h2osoi_liq_depth_intg(c) + h2osoi_liq(c,j)
+                  h2osoi_ice_depth_intg(c) = h2osoi_ice_depth_intg(c) + h2osoi_ice(c,j)
+               end if
             end if
          end do
       end do

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1399,7 +1399,8 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
-         qflx_exice_melt  =>    col_wf%qflx_exice_melt  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt_lyr  =>    col_wf%qflx_exice_melt_lyr  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt,    & ! Output: [real(r8) (:) ] integrated excess ice melt (mm H2O/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
@@ -1427,8 +1428,8 @@ contains
          qflx_glcice_melt(c) = 0._r8
          qflx_glcice_melt_diag(c) = 0._r8
          qflx_snow_melt(c) = 0._r8
-         qflx_exice_melt(c,:) = 0._r8
-         eflx_exice_melt(c) = 0._r8
+         qflx_exice_melt_lyr(c,:) = 0._r8
+         qflx_exice_melt(c) = 0._r8
       end do
 
       do j = -nlevsno+1,nlevgrnd       ! all layers
@@ -1625,7 +1626,7 @@ contains
                         ! For soil layers with excess ice, use surplus heat to melt excess ice
                         if (j >= 1 .and. use_polygonal_tundra) then
                            l = col_pp%landunit(c)
-                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then
+                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then 
                               excess_ice(c,j) = max(0._r8, wexice0(c,j) - xm2(c,j))
                            end if
                            
@@ -1674,7 +1675,7 @@ contains
 
                      ! Update liquid water including melted excess ice
                      h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
-
+                     
                      if (abs(heatr) > 0._r8) then
                         if (j == snl(c)+1) then
 
@@ -1709,8 +1710,9 @@ contains
                            l = col_pp%landunit(c)
                            if (lun_pp%ispolygon(l)) then
                               ! Excess ice melt flux (kg/m2/s)
-                              qflx_exice_melt(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
-                              
+                              qflx_exice_melt_lyr(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+                              qflx_exice_melt(c) = qflx_exice_melt(c) + max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+
                               ! Total latent heat flux (pore ice + excess ice)
                               xmf(c) = xmf(c) + hfus*(wice0(c,j) - h2osoi_ice(c,j))/dtime + &
                                                 hfus*(wexice0(c,j) - excess_ice(c,j))/dtime
@@ -1801,7 +1803,7 @@ contains
             if (lun_pp%ispolygon(l)) then
                ! Sum across all layers for energy flux
                do j = 1, nlevgrnd
-                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt(c,j) * hfus
+                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt_lyr(c,j) * hfus
                   
                   ! Update cumulative subsidence since 1989
                   ! (volume change = mass / density)

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -1335,7 +1335,7 @@ contains
     use elm_varpar       , only : nlevsno, nlevgrnd,nlevurb
     use elm_varctl       , only : iulog, use_polygonal_tundra
     use elm_varcon       , only : tfrz, hfus, grav, denice
-    use clm_time_manager , only : get_curr_date
+    use elm_time_manager , only : get_curr_date
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
     use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
     !
@@ -1399,12 +1399,12 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
-         qflx_exice_melt  =>    col_wf%qflx_exice_melt_col  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
          eflx_snomelt_u   =>    col_ef%eflx_snomelt_u  , & ! Output: [real(r8) (:)   ] urban snow melt heat flux (W/m**2)
-         eflx_exice_melt  =>    col_ef%eflx_exice_melt_col  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
+         eflx_exice_melt  =>    col_ef%eflx_exice_melt  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
 
          xmf              =>    col_ef%xmf            , &
          fact             =>    col_es%fact                         , &

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -834,7 +834,7 @@ contains
     use elm_varcon      , only : denh2o, denice, tfrz, tkwat, tkice, tkair, cpice,  cpliq, thk_bedrock
     use landunit_varcon , only : istice, istice_mec, istwet
     use column_varcon   , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv, icol_road_imperv
-    use elm_varctl      , only : iulog, use_T_rho_dependent_snowthk
+    use elm_varctl      , only : iulog, use_T_rho_dependent_snowthk, use_polygonal_tundra
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -893,6 +893,7 @@ contains
          h2osno       =>    col_ws%h2osno            , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
          h2osoi_liq   =>    col_ws%h2osoi_liq   , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          h2osoi_ice   =>    col_ws%h2osoi_ice   , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         excess_ice   =>    col_ws%excess_ice   , & ! Input:  [real(r8) (:,:) ]  excess ice (kg/m2)
          bw           =>    col_ws%bw        , & ! Output: [real(r8) (:,:) ]  partial density of water in the snow pack (ice + liquid) [kg/m3]
 
          tkmg         =>    soilstate_vars%tkmg_col          , & ! Input:  [real(r8) (:,:) ]  thermal conductivity, soil minerals  [W/m-K]
@@ -926,7 +927,13 @@ contains
                     .AND. col_pp%itype(c) /= icol_sunwall .AND. col_pp%itype(c) /= icol_shadewall .AND. &
                     col_pp%itype(c) /= icol_roof) then
 
-                  satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice)/(dz(c,j)*watsat(c,j))
+                  ! Add excess ice to saturation calculation for polygonal tundra
+                  if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                     satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice + &
+                             excess_ice(c,j)/denice) / (dz(c,j)*watsat(c,j))
+                  else
+                     satw = (h2osoi_liq(c,j)/denh2o + h2osoi_ice(c,j)/denice)/(dz(c,j)*watsat(c,j))
+                  end if
                   satw = min(1._r8, satw)
                   if (satw > .1e-6_r8) then
                      if (t_soisno(c,j) >= tfrz) then       ! Unfrozen soil
@@ -936,6 +943,14 @@ contains
                      end if
                      fl = (h2osoi_liq(c,j)/(denh2o*dz(c,j))) / (h2osoi_liq(c,j)/(denh2o*dz(c,j)) + &
                           h2osoi_ice(c,j)/(denice*dz(c,j)))
+                     
+                     ! Update liquid fraction for polygonal tundra to include excess ice
+                     if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                        fl = (h2osoi_liq(c,j)/(denh2o*dz(c,j))) / &
+                             (h2osoi_liq(c,j)/(denh2o*dz(c,j)) + &
+                              h2osoi_ice(c,j)/(denice*dz(c,j)) + &
+                              excess_ice(c,j)/(denice*dz(c,j)))
+                     end if
                      dksat = tkmg(c,j)*tkwat**(fl*watsat(c,j))*tkice**((1._r8-fl)*watsat(c,j))
                      thk(c,j) = dke*dksat + (1._r8-dke)*tkdry(c,j)
                   else
@@ -1047,6 +1062,11 @@ contains
                  .AND. col_pp%itype(c) /= icol_sunwall .AND. col_pp%itype(c) /= icol_shadewall .AND. &
                  col_pp%itype(c) /= icol_roof) then
                cv(c,j) = csol(c,j)*(1._r8-watsat(c,j))*dz(c,j) + (h2osoi_ice(c,j)*cpice + h2osoi_liq(c,j)*cpliq)
+               
+               ! Add excess ice heat capacity for soil layers in polygonal tundra
+               if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
+                  cv(c,j) = cv(c,j) + excess_ice(c,j)*cpice
+               end if
             else if (lun_pp%itype(l) == istwet) then
                cv(c,j) = (h2osoi_ice(c,j)*cpice + h2osoi_liq(c,j)*cpliq)
                if (j > nlevbed) cv(c,j) = csol(c,j)*dz(c,j)
@@ -1313,8 +1333,9 @@ contains
     ! !USES:
       !$acc routine seq
     use elm_varpar       , only : nlevsno, nlevgrnd,nlevurb
-    use elm_varctl       , only : iulog
-    use elm_varcon       , only : tfrz, hfus, grav
+    use elm_varctl       , only : iulog, use_polygonal_tundra
+    use elm_varcon       , only : tfrz, hfus, grav, denice
+    use clm_time_manager , only : get_curr_date
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall, icol_road_perv
     use landunit_varcon  , only : istsoil, istcrop, istice_mec,istice
     !
@@ -1342,6 +1363,9 @@ contains
     real(r8) :: propor                             !proportionality constant (-)
     real(r8) :: tinc(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)  !t(n+1)-t(n) (K)
     real(r8) :: smp                                !frozen water potential (mm)
+    real(r8) :: wexice0(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd) ! initial excess ice (kg/m2)
+    real(r8) :: xm2(bounds%begc:bounds%endc,-nlevsno+1:nlevgrnd)     ! excess melt for excess ice (kg/m2)
+    integer  :: year, mon, day, sec                ! for subsidence tracking since 1989
     
     character(len=64) :: event 
     !-----------------------------------------------------------------------
@@ -1363,6 +1387,8 @@ contains
          h2osno           =>    col_ws%h2osno          , & ! Output: [real(r8) (:)   ] snow water (mm H2O)
          h2osoi_liq       =>    col_ws%h2osoi_liq      , & ! Output: [real(r8) (:,:) ] liquid water (kg/m2) (new)
          h2osoi_ice       =>    col_ws%h2osoi_ice      , & ! Output: [real(r8) (:,:) ] ice lens (kg/m2) (new)
+         excess_ice       =>    col_ws%excess_ice      , & ! InOut:  [real(r8) (:,:) ] excess ice (kg/m2)
+         iwp_subsidence   =>    col_ws%iwp_subsidence  , & ! InOut:  [real(r8) (:)   ] cumulative subsidence (m)
 
          qflx_snow_melt   =>    col_wf%qflx_snow_melt   , & ! Output: [real(r8) (:)   ] net snow melt
          qflx_snofrz_lyr  =>    col_wf%qflx_snofrz_lyr  , & ! Output: [real(r8) (:,:) ] snow freezing rate (positive definite) (col,lyr) [kg m-2 s-1]
@@ -1373,10 +1399,12 @@ contains
          qflx_glcice_melt_diag =>    col_wf%qflx_glcice_melt_diag , & ! Output: [real(r8) (:)   ] ice melt (positive definite) (mm H2O/s)
          qflx_snomelt     =>    col_wf%qflx_snomelt     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
          qflx_snomelt_lyr     =>    col_wf%qflx_snomelt_lyr     , & ! Output: [real(r8) (:)   ] snow melt (mm H2O /s)
+         qflx_exice_melt  =>    col_wf%qflx_exice_melt_col  , & ! Output: [real(r8) (:,:) ] excess ice melt rate (kg/m2/s)
 
          eflx_snomelt     =>    col_ef%eflx_snomelt    , & ! Output: [real(r8) (:)   ] snow melt heat flux (W/m**2)
          eflx_snomelt_r   =>    col_ef%eflx_snomelt_r  , & ! Output: [real(r8) (:)   ] rural snow melt heat flux (W/m**2)
          eflx_snomelt_u   =>    col_ef%eflx_snomelt_u  , & ! Output: [real(r8) (:)   ] urban snow melt heat flux (W/m**2)
+         eflx_exice_melt  =>    col_ef%eflx_exice_melt_col  , & ! Output: [real(r8) (:)   ] excess ice latent heat (W/m2)
 
          xmf              =>    col_ef%xmf            , &
          fact             =>    col_es%fact                         , &
@@ -1399,6 +1427,8 @@ contains
          qflx_glcice_melt(c) = 0._r8
          qflx_glcice_melt_diag(c) = 0._r8
          qflx_snow_melt(c) = 0._r8
+         qflx_exice_melt(c,:) = 0._r8
+         eflx_exice_melt(c) = 0._r8
       end do
 
       do j = -nlevsno+1,nlevgrnd       ! all layers
@@ -1410,9 +1440,20 @@ contains
                imelt(c,j) = 0
                hm(c,j) = 0._r8
                xm(c,j) = 0._r8
+               xm2(c,j) = 0._r8
                wice0(c,j) = h2osoi_ice(c,j)
                wliq0(c,j) = h2osoi_liq(c,j)
-               wmass0(c,j) = h2osoi_ice(c,j) + h2osoi_liq(c,j)
+               wexice0(c,j) = 0._r8
+               
+               ! Store initial excess ice for soil layers
+               if (j >= 1 .and. use_polygonal_tundra) then
+                  l = col_pp%landunit(c)
+                  if (lun_pp%ispolygon(l)) then
+                     wexice0(c,j) = excess_ice(c,j)
+                  end if
+               end if
+               
+               wmass0(c,j) = h2osoi_ice(c,j) + h2osoi_liq(c,j) + wexice0(c,j)
             endif   ! end of snow layer if-block
          end do   ! end of column-loop
       enddo   ! end of level-loop
@@ -1574,23 +1615,65 @@ contains
                      endif
 
                      heatr = 0._r8
-                     if (xm(c,j) > 0._r8) then
-                        h2osoi_ice(c,j) = max(0._r8, wice0(c,j)-xm(c,j))
-                        heatr = hm(c,j) - hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
-                     else if (xm(c,j) < 0._r8) then
+                     if (xm(c,j) > 0._r8) then  ! Melting
+                        ! First melt pore ice
+                        h2osoi_ice(c,j) = max(0._r8, wice0(c,j) - xm(c,j))
+                        
+                        ! Calculate surplus heat after melting pore ice
+                        xm2(c,j) = max(0._r8, xm(c,j) - wice0(c,j))
+                        
+                        ! For soil layers with excess ice, use surplus heat to melt excess ice
+                        if (j >= 1 .and. use_polygonal_tundra) then
+                           l = col_pp%landunit(c)
+                           if (lun_pp%ispolygon(l) .and. excess_ice(c,j) > 0._r8 .and. xm2(c,j) > 0._r8) then
+                              excess_ice(c,j) = max(0._r8, wexice0(c,j) - xm2(c,j))
+                           end if
+                           
+                           ! Heat residual including both pore ice and excess ice latent heat
+                           heatr = hm(c,j) - hfus * (wexice0(c,j) - excess_ice(c,j) + &
+                                                      wice0(c,j) - h2osoi_ice(c,j)) / dtime
+                        else
+                           ! Standard calculation (snow or non-polygonal soil)
+                           heatr = hm(c,j) - hfus * (wice0(c,j) - h2osoi_ice(c,j)) / dtime
+                        endif
+                        
+                     else if (xm(c,j) < 0._r8) then  ! Freezing
+                        ! Excess ice does NOT refreeze
                         if (j <= 0) then
                            h2osoi_ice(c,j) = min(wmass0(c,j), wice0(c,j)-xm(c,j))  ! snow
                         else
-                           if (wmass0(c,j) < supercool(c,j)) then
-                              h2osoi_ice(c,j) = 0._r8
+                           if (use_polygonal_tundra) then
+                              l = col_pp%landunit(c)
+                              if (lun_pp%ispolygon(l)) then
+                                 ! Exclude excess ice from freezable water
+                                 if (wmass0(c,j) - wexice0(c,j) < supercool(c,j)) then
+                                    h2osoi_ice(c,j) = 0._r8
+                                 else
+                                    h2osoi_ice(c,j) = min(wmass0(c,j) - wexice0(c,j) - supercool(c,j), &
+                                                           wice0(c,j) - xm(c,j))
+                                 end if
+                              else
+                                 ! Standard freezing for non-polygonal
+                                 if (wmass0(c,j) < supercool(c,j)) then
+                                    h2osoi_ice(c,j) = 0._r8
+                                 else
+                                    h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j), wice0(c,j)-xm(c,j))
+                                 end if
+                              end if
                            else
-                              h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j),wice0(c,j)-xm(c,j))
-                           endif
+                              ! Standard freezing
+                              if (wmass0(c,j) < supercool(c,j)) then
+                                 h2osoi_ice(c,j) = 0._r8
+                              else
+                                 h2osoi_ice(c,j) = min(wmass0(c,j) - supercool(c,j),wice0(c,j)-xm(c,j))
+                              endif
+                           end if
                         endif
                         heatr = hm(c,j) - hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      endif
 
-                     h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j))
+                     ! Update liquid water including melted excess ice
+                     h2osoi_liq(c,j) = max(0._r8,wmass0(c,j)-h2osoi_ice(c,j)-excess_ice(c,j))
 
                      if (abs(heatr) > 0._r8) then
                         if (j == snl(c)+1) then
@@ -1621,8 +1704,24 @@ contains
                      endif  ! end of heatr > 0 if-block
 
                      if (j >= 1) then
-                        xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                        ! Calculate melt fluxes including excess ice
+                        if (use_polygonal_tundra) then
+                           l = col_pp%landunit(c)
+                           if (lun_pp%ispolygon(l)) then
+                              ! Excess ice melt flux (kg/m2/s)
+                              qflx_exice_melt(c,j) = max(0._r8, (wexice0(c,j) - excess_ice(c,j)) / dtime)
+                              
+                              ! Total latent heat flux (pore ice + excess ice)
+                              xmf(c) = xmf(c) + hfus*(wice0(c,j) - h2osoi_ice(c,j))/dtime + &
+                                                hfus*(wexice0(c,j) - excess_ice(c,j))/dtime
+                           else
+                              xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                           end if
+                        else
+                           xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
+                        end if
                      else
+                        ! Snow layers
                         xmf(c) = xmf(c) + hfus*(wice0(c,j)-h2osoi_ice(c,j))/dtime
                      endif
 
@@ -1684,6 +1783,34 @@ contains
             eflx_snomelt_u(c) = eflx_snomelt(c)
          else if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
             eflx_snomelt_r(c) = eflx_snomelt(c)
+         end if
+      end do
+      
+      ! Calculate excess ice energy flux (following snow melt pattern)
+      ! and update cumulative subsidence since 1989
+      call get_curr_date(year, mon, day, sec)
+      
+      do fc = 1,num_nolakec
+         c = filter_nolakec(fc)
+         
+         ! Column-integrated excess ice latent heat flux (W/m2)
+         eflx_exice_melt(c) = 0._r8
+         
+         if (use_polygonal_tundra) then
+            l = col_pp%landunit(c)
+            if (lun_pp%ispolygon(l)) then
+               ! Sum across all layers for energy flux
+               do j = 1, nlevgrnd
+                  eflx_exice_melt(c) = eflx_exice_melt(c) + qflx_exice_melt(c,j) * hfus
+                  
+                  ! Update cumulative subsidence since 1989
+                  ! (volume change = mass / density)
+                  if (year >= 1989 .and. wexice0(c,j) > excess_ice(c,j)) then
+                     iwp_subsidence(c) = iwp_subsidence(c) + &
+                                         (wexice0(c,j) - excess_ice(c,j)) / denice
+                  end if
+               end do
+            end if
          end if
       end do
 

--- a/components/elm/src/biogeophys/WaterfluxType.F90
+++ b/components/elm/src/biogeophys/WaterfluxType.F90
@@ -79,9 +79,8 @@ module WaterfluxType
      real(r8), pointer :: qflx_deficit_col         (:)   ! col water deficit to keep non-negative liquid water content (mm H2O)   
      real(r8), pointer :: qflx_floodc_col          (:)   ! col flood water flux at column level
      real(r8), pointer :: qflx_sl_top_soil_col     (:)   ! col liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)
-      real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
-      real(r8), pointer :: qflx_exice_melt_col      (:,:) ! col excess ice melt rate (kg/m2/s) per layer
-      real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
+     real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
+     real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
      real(r8), pointer :: qflx_qrgwl_col           (:)   ! col qflx_surf at glaciers, wetlands, lakes
      real(r8), pointer :: qflx_runoff_col          (:)   ! col total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
      real(r8), pointer :: qflx_runoff_r_col        (:)   ! col Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -250,7 +249,6 @@ contains
     allocate(this%qflx_h2osfc_surf_col     (begc:endc))              ; this%qflx_h2osfc_surf_col     (:)   = nan
     allocate(this%qflx_snow_h2osfc_col     (begc:endc))              ; this%qflx_snow_h2osfc_col     (:)   = nan
     allocate(this%qflx_snomelt_col         (begc:endc))              ; this%qflx_snomelt_col         (:)   = nan
-    allocate(this%qflx_exice_melt_col      (begc:endc,1:nlevgrnd)) ; this%qflx_exice_melt_col      (:,:) = nan
     allocate(this%qflx_snow_melt_col       (begc:endc))              ; this%qflx_snow_melt_col       (:)   = nan
     allocate(this%qflx_snofrz_col          (begc:endc))              ; this%qflx_snofrz_col          (:)   = nan
     allocate(this%qflx_snofrz_lyr_col      (begc:endc,-nlevsno+1:0)) ; this%qflx_snofrz_lyr_col      (:,:) = nan

--- a/components/elm/src/biogeophys/WaterfluxType.F90
+++ b/components/elm/src/biogeophys/WaterfluxType.F90
@@ -79,8 +79,9 @@ module WaterfluxType
      real(r8), pointer :: qflx_deficit_col         (:)   ! col water deficit to keep non-negative liquid water content (mm H2O)   
      real(r8), pointer :: qflx_floodc_col          (:)   ! col flood water flux at column level
      real(r8), pointer :: qflx_sl_top_soil_col     (:)   ! col liquid water + ice from layer above soil to top soil layer or sent to qflx_qrgwl (mm H2O/s)
-     real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
-     real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
+      real(r8), pointer :: qflx_snomelt_col         (:)   ! col snow melt (mm H2O /s)
+      real(r8), pointer :: qflx_exice_melt_col      (:,:) ! col excess ice melt rate (kg/m2/s) per layer
+      real(r8), pointer :: qflx_snow_melt_col       (:)   ! col snow melt (net)
      real(r8), pointer :: qflx_qrgwl_col           (:)   ! col qflx_surf at glaciers, wetlands, lakes
      real(r8), pointer :: qflx_runoff_col          (:)   ! col total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
      real(r8), pointer :: qflx_runoff_r_col        (:)   ! col Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -249,6 +250,7 @@ contains
     allocate(this%qflx_h2osfc_surf_col     (begc:endc))              ; this%qflx_h2osfc_surf_col     (:)   = nan
     allocate(this%qflx_snow_h2osfc_col     (begc:endc))              ; this%qflx_snow_h2osfc_col     (:)   = nan
     allocate(this%qflx_snomelt_col         (begc:endc))              ; this%qflx_snomelt_col         (:)   = nan
+    allocate(this%qflx_exice_melt_col      (begc:endc,1:nlevgrnd)) ; this%qflx_exice_melt_col      (:,:) = nan
     allocate(this%qflx_snow_melt_col       (begc:endc))              ; this%qflx_snow_melt_col       (:)   = nan
     allocate(this%qflx_snofrz_col          (begc:endc))              ; this%qflx_snofrz_col          (:)   = nan
     allocate(this%qflx_snofrz_lyr_col      (begc:endc,-nlevsno+1:0)) ; this%qflx_snofrz_lyr_col      (:,:) = nan

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -175,8 +175,8 @@ module ColumnDataType
     real(r8), pointer :: iwp_exclvol      (:) => null() ! ice wedge polygon excluded volume (m)
     real(r8), pointer :: iwp_ddep         (:) => null() ! ice wedge polygon depression depth (m)
     real(r8), pointer :: iwp_subsidence   (:) => null() ! ice wedge polygon ground subsidence (m)
-    real(r8), pointer :: excess_ice     (:,:) => null() ! excess ground ice in column (1:nlevgrnd) (0 to 1)
-    real(r8), pointer :: frac_melted    (:,:) => null() ! fraction of layer that has ever thawed (for tracking excess ice removal) (0 to 1)
+    real(r8), pointer :: excess_ice          (:,:) => null() ! excess ground ice mass (kg/m2) (1:nlevgrnd)
+    real(r8), pointer :: excess_ice_volfrac  (:,:) => null() ! excess ice volumetric fraction (0 to 1) (1:nlevgrnd)
     real(r8), pointer :: h2osfc_p         (:) => null() !!! DEBUG
 
   contains
@@ -1471,8 +1471,8 @@ contains
       allocate(this%iwp_exclvol        (begc:endc))                   ; this%iwp_exclvol      (:) = spval
       allocate(this%iwp_ddep           (begc:endc))                   ; this%iwp_ddep         (:) = spval
       allocate(this%iwp_subsidence     (begc:endc))                   ; this%iwp_subsidence   (:) = spval
-      allocate(this%frac_melted        (begc:endc,1:nlevgrnd))        ; this%frac_melted    (:,:) = spval
       allocate(this%excess_ice         (begc:endc,1:nlevgrnd))        ; this%excess_ice     (:,:) = spval
+      allocate(this%excess_ice_volfrac (begc:endc,1:nlevgrnd))        ; this%excess_ice_volfrac(:,:) = spval
     end if
 
     !-----------------------------------------------------------------------
@@ -1514,14 +1514,17 @@ contains
       this%iwp_ddep(begc:endc)          = spval
       this%iwp_exclvol(begc:endc)       = spval
       this%iwp_microrel(begc:endc)      = spval
-      this%frac_melted(begc:endc,:)     = spval
       this%excess_ice(begc:endc,:)      = spval
+      this%excess_ice_volfrac(begc:endc,:) = spval
 
-      call hist_addfld2d (fname='EXCESS_ICE', units = '1', type2d='levgrnd', &
-           avgflag='A', long_name='Excess ground ice (0 to 1)', &
+      ! History output for excess ice mass per layer (for debugging)
+      call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
+           avgflag='A', long_name='excess ground ice mass per layer', &
            ptr_col=this%excess_ice, l2g_scale_type='veg')
+      
+      ! Cumulative subsidence since 1989
       call hist_addfld1d (fname="SUBSIDENCE", units='m', avgflag='A', &
-            long_name='ground subsidence (m)', ptr_col=this%iwp_subsidence)
+            long_name='cumulative ground subsidence since 1989', ptr_col=this%iwp_subsidence)
       call hist_addfld1d (fname="DEPRESS_DEPTH", units='m', avgflag='A', &
             long_name='microtopographic depression depth (m)', ptr_col=this%iwp_ddep)
       call hist_addfld1d (fname="EXCLUDED_VOL", units='m', avgflag='A', &
@@ -1529,9 +1532,6 @@ contains
             ptr_col=this%iwp_exclvol)
       call hist_addfld1d (fname="MICROREL", units='m', avgflag='A', &
             long_name='microtopographic relief (m)', ptr_col=this%iwp_microrel)
-      call hist_addfld2d (fname="FRAC_MELTED", units='-', type2d='levgrnd', &
-            avgflag='A', long_name='fraction of layer that has melted (-)', &
-            ptr_col=this%frac_melted, l2g_scale_type='veg')
     endif
     !/polygonal tundra
 
@@ -1870,9 +1870,16 @@ contains
        this%h2osoi_liq_old(c,:) = this%h2osoi_liq(c,:)
        this%h2osoi_ice_old(c,:) = this%h2osoi_ice(c,:)
        if (use_polygonal_tundra .and. lun_pp%ispolygon(l)) then
-         this%excess_ice(c,:) = 0.36_r8
+         ! Initialize volumetric fraction to 36%
+         this%excess_ice_volfrac(c,:) = 0.36_r8
+         
+         ! Convert to mass (kg/m2)
+         do j = 1, nlevgrnd
+            this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+         end do
+         
          this%iwp_subsidence(c) = 0._r8
-         this%frac_melted(c,:)  = 0._r8
+         
          ! set initial microtopographic parameters
          if (lun_pp%polygontype(l) .eq. ilowcenpoly) then
             this%iwp_microrel(c) = 0.4_r8
@@ -1951,13 +1958,54 @@ contains
          interpinic_flag='interp', readvar=readvar, data=this%h2osoi_ice)
 
     if (use_polygonal_tundra) then
-      call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+      ! Write/read volumetric fraction with new name
+      call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE_FRAC', xtype=ncd_double, &
            dim1name='column', dim2name='levgrnd', switchdim=.true., &
-           long_name='excess ground ice (0 to 1)', units='1', &
-           interpinic_flag='interp', readvar=readvar, data=this%excess_ice)
+           long_name='excess ground ice volumetric fraction (0 to 1)', units='1', &
+           interpinic_flag='interp', readvar=readvar, data=this%excess_ice_volfrac)
+      
+      ! Convert between volumetric and mass
+      if (flag == 'read') then
+          ! Backward compatibility: try old name if new name fails
+          if (.not. readvar) then
+              call restartvar(ncid=ncid, flag=flag, varname='EXCESS_ICE', xtype=ncd_double, &
+                   dim1name='column', dim2name='levgrnd', switchdim=.true., &
+                   long_name='excess ground ice (old format)', units='1', &
+                   interpinic_flag='interp', readvar=readvar, data=this%excess_ice_volfrac)
+              if (readvar) then
+                  write(iulog,*) 'Read EXCESS_ICE from old format, converted to EXCESS_ICE_FRAC'
+              end if
+          end if
+          
+          ! Convert from volumetric to mass
+          do c = bounds%begc, bounds%endc
+              l = col_pp%landunit(c)
+              if (lun_pp%ispolygon(l)) then
+                  do j = 1, nlevgrnd
+                      this%excess_ice(c,j) = this%excess_ice_volfrac(c,j) * col_pp%dz(c,j) * denice
+                  end do
+              end if
+          end do
+      else if (flag == 'write') then
+          ! Convert from mass to volumetric before writing
+          do c = bounds%begc, bounds%endc
+              l = col_pp%landunit(c)
+              if (lun_pp%ispolygon(l)) then
+                  do j = 1, nlevgrnd
+                      if (col_pp%dz(c,j) > 0._r8) then
+                          this%excess_ice_volfrac(c,j) = this%excess_ice(c,j) / (col_pp%dz(c,j) * denice)
+                      else
+                          this%excess_ice_volfrac(c,j) = 0._r8
+                      end if
+                  end do
+              end if
+          end do
+      end if
+      
+      ! SUBSIDENCE - cumulative tracking since 1989
       call restartvar(ncid=ncid, flag=flag, varname='SUBSIDENCE', xtype=ncd_double, &
            dim1name='column', &
-           long_name='ground subsidence', units='m', &
+           long_name='cumulative ground subsidence since 1989', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_subsidence)
       call restartvar(ncid=ncid, flag=flag, varname='DEPRESS_DEPTH', xtype=ncd_double, &
            dim1name='column', &
@@ -1971,10 +2019,6 @@ contains
            dim1name='column', &
            long_name='microtopographic relief', units='m', &
            interpinic_flag='interp', readvar=readvar, data=this%iwp_microrel)
-      call restartvar(ncid=ncid, flag=flag, varname='FRAC_MELTED', xtype=ncd_double, &
-           dim1name='column', dim2name='levgrnd', switchdim=.true., &
-           long_name='fraction of layer that has ever melted', units='-', &
-           interpinic_flag='interp', readvar=readvar, data=this%frac_melted)
     end if
 
     call restartvar(ncid=ncid, flag=flag, varname='SOILP', xtype=ncd_double,  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -423,6 +423,7 @@ module ColumnDataType
     real(r8), pointer :: eflx_snomelt            (:)   => null() ! snow melt heat flux (W/m**2)
     real(r8), pointer :: eflx_snomelt_r          (:)   => null() ! rural snow melt heat flux (W/m2)
     real(r8), pointer :: eflx_snomelt_u          (:)   => null() ! urban snow melt heat flux (W/m2)
+    real(r8), pointer :: eflx_exice_melt         (:)   => null() ! excess ice melt latent heat flux (W/m2)
     real(r8), pointer :: eflx_bot                (:)   => null() ! heat flux from beneath the soil or ice column (W/m2)
     real(r8), pointer :: eflx_fgr12              (:)   => null() ! ground heat flux between soil layers 1 and 2 (W/m2)
     real(r8), pointer :: eflx_fgr                (:,:) => null() ! (rural) soil downward heat flux (W/m2) (1:nlevgrnd)  (pos upward; usually eflx_bot >= 0)
@@ -504,6 +505,7 @@ module ColumnDataType
     real(r8), pointer :: qflx_snomelt         (:)   => null() ! snow melt (mm H2O /s)
     real(r8), pointer :: qflx_snow_melt       (:)   => null() ! snow melt (net)
     real(r8), pointer :: qflx_snomelt_lyr     (:,:) => null() ! snow melt (net)
+    real(r8), pointer :: qflx_exice_melt      (:,:) => null() ! excess ice melt (kg/m2/s) per layer
     real(r8), pointer :: qflx_qrgwl           (:)   => null() ! qflx_surf at glaciers, wetlands, lakes
     real(r8), pointer :: qflx_runoff          (:)   => null() ! total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
     real(r8), pointer :: qflx_runoff_r        (:)   => null() ! Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -1762,9 +1764,6 @@ contains
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif
-                   if (use_polygonal_tundra) then
-                     this%frac_melted(c,j) = 0._r8
-                   end if
                 endif
              end do
           else if (lun_pp%urbpoi(l)) then
@@ -5713,6 +5712,7 @@ contains
     allocate(this%eflx_snomelt         (begc:endc))              ; this%eflx_snomelt         (:)   = spval
     allocate(this%eflx_snomelt_r       (begc:endc))              ; this%eflx_snomelt_r       (:)   = spval
     allocate(this%eflx_snomelt_u       (begc:endc))              ; this%eflx_snomelt_u       (:)   = spval
+    allocate(this%eflx_exice_melt      (begc:endc))              ; this%eflx_exice_melt      (:)   = spval
     allocate(this%eflx_bot             (begc:endc))              ; this%eflx_bot             (:)   = spval
     allocate(this%eflx_fgr12           (begc:endc))              ; this%eflx_fgr12           (:)   = spval
     allocate(this%eflx_fgr             (begc:endc, 1:nlevgrnd))  ; this%eflx_fgr             (:,:) = spval
@@ -5755,7 +5755,10 @@ contains
      call hist_addfld1d (fname='FSM_U',  units='W/m^2',  &
           avgflag='A', long_name='Urban snow melt heat flux', &
            ptr_col=this%eflx_snomelt_u, c2l_scale_type='urbanf', set_nourb=spval)
-
+    this%eflx_exice_melt(begc:endc) = spval
+     call hist_addfld1d (fname='EXICE_MELT_COL',  units='W/m^2',  &
+          avgflag='A', long_name='Excess ice melt latent heat flux', &
+           ptr_col=this%eflx_exice_melt, c2l_scale_type='urbanf', set_nourb=spval)
     this%eflx_building_heat(begc:endc) = spval
      call hist_addfld1d (fname='BUILDHEAT', units='W/m^2',  &
           avgflag='A', long_name='heat flux from urban building interior to walls and roof', &
@@ -5899,6 +5902,7 @@ contains
     allocate(this%qflx_snomelt           (begc:endc))             ; this%qflx_snomelt         (:)   = spval
     allocate(this%qflx_snomelt_lyr       (begc:endc,-nlevsno+1:0)) ; this%qflx_snomelt_lyr    (:,:) = spval
     allocate(this%qflx_snow_melt         (begc:endc))             ; this%qflx_snow_melt       (:)   = spval
+    allocate(this%qflx_exice_melt        (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt      (:,:) = spval
     allocate(this%qflx_qrgwl             (begc:endc))             ; this%qflx_qrgwl           (:)   = spval
     allocate(this%qflx_runoff            (begc:endc))             ; this%qflx_runoff          (:)   = spval
     allocate(this%qflx_runoff_r          (begc:endc))             ; this%qflx_runoff_r        (:)   = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -505,7 +505,8 @@ module ColumnDataType
     real(r8), pointer :: qflx_snomelt         (:)   => null() ! snow melt (mm H2O /s)
     real(r8), pointer :: qflx_snow_melt       (:)   => null() ! snow melt (net)
     real(r8), pointer :: qflx_snomelt_lyr     (:,:) => null() ! snow melt (net)
-    real(r8), pointer :: qflx_exice_melt      (:,:) => null() ! excess ice melt (kg/m2/s) per layer
+    real(r8), pointer :: qflx_exice_melt      (:)   => null() ! excess ice melt (mm H2O/s)
+    real(r8), pointer :: qflx_exice_melt_lyr  (:,:) => null() ! excess ice melt (kg/m2/s) per layer
     real(r8), pointer :: qflx_qrgwl           (:)   => null() ! qflx_surf at glaciers, wetlands, lakes
     real(r8), pointer :: qflx_runoff          (:)   => null() ! total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
     real(r8), pointer :: qflx_runoff_r        (:)   => null() ! Rural total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -1516,8 +1517,8 @@ contains
       this%iwp_ddep(begc:endc)          = spval
       this%iwp_exclvol(begc:endc)       = spval
       this%iwp_microrel(begc:endc)      = spval
-      this%excess_ice(begc:endc,:)      = spval
-      this%excess_ice_volfrac(begc:endc,:) = spval
+      this%excess_ice(begc:endc,:)      = 0._r8 ! specify as zero to avoid any excess ice in non-polygonal tundra cells
+      this%excess_ice_volfrac(begc:endc,:) = 0._r8
 
       ! History output for excess ice mass per layer (for debugging)
       call hist_addfld2d (fname='EXCESS_ICE', units='kg/m2', type2d='levgrnd', &
@@ -1757,10 +1758,8 @@ contains
                 if (j > nlevbed) then
                    this%h2osoi_vol(c,j) = 0.0_r8
                 else
-		             if (use_fates .or. use_hydrstress) then
+		             if (use_fates .or. use_hydrstress .or. use_arctic_init) then
                       this%h2osoi_vol(c,j) = 0.70_r8*watsat_input(c,j) !0.15_r8 to avoid very dry conditions that cause errors in FATES
-                   else if (use_arctic_init) then
-                      this%h2osoi_vol(c,j) = watsat_input(c,j) ! start saturated for arctic
                    else
                       this%h2osoi_vol(c,j) = 0.15_r8
                    endif
@@ -5902,7 +5901,8 @@ contains
     allocate(this%qflx_snomelt           (begc:endc))             ; this%qflx_snomelt         (:)   = spval
     allocate(this%qflx_snomelt_lyr       (begc:endc,-nlevsno+1:0)) ; this%qflx_snomelt_lyr    (:,:) = spval
     allocate(this%qflx_snow_melt         (begc:endc))             ; this%qflx_snow_melt       (:)   = spval
-    allocate(this%qflx_exice_melt        (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt      (:,:) = spval
+    allocate(this%qflx_exice_melt        (begc:endc))             ; this%qflx_exice_melt      (:)   = spval
+    allocate(this%qflx_exice_melt_lyr    (begc:endc,1:nlevgrnd))  ; this%qflx_exice_melt_lyr  (:,:) = spval
     allocate(this%qflx_qrgwl             (begc:endc))             ; this%qflx_qrgwl           (:)   = spval
     allocate(this%qflx_runoff            (begc:endc))             ; this%qflx_runoff          (:)   = spval
     allocate(this%qflx_runoff_r          (begc:endc))             ; this%qflx_runoff_r        (:)   = spval
@@ -6015,6 +6015,16 @@ contains
           avgflag='A', long_name='snow melt per snow layer', &
            ptr_col=this%qflx_snomelt_lyr,no_snow_behavior=no_snow_normal, c2l_scale_type='urbanf')
 
+    this%qflx_exice_melt(begc:endc) = spval
+     call hist_addfld1d (fname='QEXCESSICE',  units='mm/s',  &
+          avgflag='A', long_name='excess ice melt', &
+           ptr_col=this%qflx_exice_melt, c2l_scale_type='urbanf')
+
+    this%qflx_exice_melt_lyr(begc:endc,1:nlevgrnd) = spval
+     call hist_addfld2d (fname='QEXCESSICE_LYR',  units='mm/s',type2d='levgrnd',&
+          avgflag='A', long_name='excess ice per soil layer', &
+           ptr_col=this%qflx_exice_melt_lyr, c2l_scale_type='urbanf')
+
     this%qflx_qrgwl(begc:endc) = spval
      call hist_addfld1d (fname='QRGWL',  units='mm/s',  &
           avgflag='A', long_name='surface runoff at glaciers (liquid only), wetlands, lakes', &
@@ -6112,7 +6122,8 @@ contains
     this%qflx_dew_snow (begc:endc) = 0.0_r8
 
     this%qflx_h2osfc_surf(begc:endc) = 0._r8
-    this%qflx_snow_melt  (begc:endc)   = 0._r8
+    this%qflx_snow_melt  (begc:endc) = 0._r8
+    this%qflx_exice_melt (begc:endc) = 0._r8
 
     this%dwb(begc:endc) = 0._r8
     this%qflx_surf_irrig(begc:endc) = 0._r8


### PR DESCRIPTION
Replace the original subsidence routine in ActiveLayerMod by coupling excess ice to the energy balance equations now.

Major Changes:
- Excess ice now stored as mass (kg/m2) internally, volumetric fraction for restart I/O only
- Phase change (melting/freezing) controlled by energy balance in PhaseChange_beta
- Sequential melting: pore ice melts first, then excess ice with surplus heat
- Excess ice does NOT refreeze
- Subsidence tracked cumulatively since 1989 based on actual mass change
- Geometric melting code in ActiveLayerMod commented out but retained